### PR TITLE
feat: replace PATH-based wrapper with shell hook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ OpenCode plugin that replicates Claude Code's persistent memory system. TypeScri
 
 ```
 .
-├── bin/opencode         # Bash wrapper: post-session memory extraction via --fork
+├── bin/opencode-memory  # Bash wrapper: shell hook install + post-session memory extraction via --fork
 ├── src/
 │   ├── index.ts         # Plugin entry: MemoryPlugin export, 5 tools + system prompt hook
 │   ├── memory.ts        # CRUD: save/delete/list/search/read + MEMORY.md index management
@@ -26,7 +26,8 @@ OpenCode plugin that replicates Claude Code's persistent memory system. TypeScri
 | Fix path resolution or worktree sharing | `src/paths.ts` — `getMemoryDir()`, `findCanonicalGitRoot()` |
 | Modify what the agent sees about memory | `src/prompt.ts` — `buildMemorySystemPrompt()` |
 | Change which memories are auto-recalled | `src/recall.ts` — `recallRelevantMemories()` |
-| Fix post-session extraction | `bin/opencode` — bash wrapper |
+| Fix post-session extraction | `bin/opencode-memory` — bash wrapper |
+| Fix shell hook install/uninstall | `bin/opencode-memory` — `install`/`uninstall` subcommands |
 
 ## Critical Coupling
 
@@ -91,5 +92,6 @@ git push origin main
 
 - Memory directory is `~/.claude/projects/<sanitizePath(canonicalGitRoot)>/memory/` — shared with Claude Code bidirectionally
 - `sanitizePath()` + `djb2Hash()` are exact copies from Claude Code source to guarantee byte-identical paths
-- The bash wrapper (`bin/opencode`) uses `mktemp` timestamp comparison to detect if the main agent already wrote memories — if so, extraction is skipped
+- The bash wrapper (`bin/opencode-memory`) uses `mktemp` timestamp comparison to detect if the main agent already wrote memories — if so, extraction is skipped
+- Shell hook is installed via `opencode-memory install`, which writes an `opencode()` function to `~/.zshrc` or `~/.bashrc` — shell functions take priority over PATH binaries
 - `package-lock.json` is gitignored (Bun runtime, not npm)

--- a/README.md
+++ b/README.md
@@ -71,11 +71,13 @@ Worktrees of the same repo share the same memory directory
 
 ```bash
 npm install -g opencode-claude-memory
+opencode-memory install   # one-time: installs shell hook
 ```
 
 This installs:
 - The **plugin** — memory tools + system prompt injection
-- An `opencode` **wrapper** — auto-extracts memories after each session
+- The `opencode-memory` **CLI** — wraps opencode with post-session memory extraction
+- A **shell hook** — defines an `opencode()` function in your `.zshrc`/`.bashrc` that delegates to `opencode-memory`
 
 ### 2. Configure
 
@@ -104,10 +106,11 @@ When you exit, memories are extracted in the background — zero blocking.
 <summary>🗑️ Uninstall</summary>
 
 ```bash
+opencode-memory uninstall   # removes shell hook from .zshrc/.bashrc
 npm uninstall -g opencode-claude-memory
 ```
 
-This removes the wrapper and the plugin. Your saved memories in `~/.claude/projects/` are **not** deleted.
+This removes the shell hook, the CLI, and the plugin. Your saved memories in `~/.claude/projects/` are **not** deleted.
 
 </details>
 
@@ -115,20 +118,21 @@ This removes the wrapper and the plugin. Your saved memories in `~/.claude/proje
 
 ```mermaid
 graph LR
-    A[You run opencode] --> B[Wrapper finds real binary]
-    B --> C[Runs opencode normally]
-    C --> D[You exit]
-    D --> E[Get latest session ID]
+    A[You run opencode] --> B[Shell hook calls opencode-memory]
+    B --> C[opencode-memory finds real binary]
+    C --> D[Runs opencode normally]
+    D --> E[You exit]
     E --> F[Fork session + extract memories]
     F --> G[Memories saved to ~/.claude/projects/]
 ```
 
-The wrapper is a drop-in replacement that:
+The shell hook defines an `opencode()` function that delegates to `opencode-memory`:
 
-1. Scans `PATH` to find the real `opencode` binary (skipping itself)
-2. Runs it with all your arguments
-3. After you exit, forks the session with a memory extraction prompt
-4. Extraction runs **in the background** — you're never blocked
+1. Shell function intercepts `opencode` command (higher priority than PATH)
+2. `opencode-memory` finds the real `opencode` binary in PATH
+3. Runs it with all your arguments
+4. After you exit, forks the session with a memory extraction prompt
+5. Extraction runs **in the background** — you're never blocked
 
 ### What "1:1 Replica" Means
 

--- a/bin/opencode-memory
+++ b/bin/opencode-memory
@@ -1,23 +1,25 @@
 #!/usr/bin/env bash
 #
-# opencode (memory wrapper) — Drop-in replacement that wraps the real opencode
-# binary, then automatically extracts and saves memories after the session ends.
+# opencode-memory — Wrapper for OpenCode with automatic memory extraction.
 #
-# Install by placing this earlier in PATH than the real opencode binary.
-# The script finds the real opencode by scanning PATH and skipping itself.
+# Installs a shell hook (function) that intercepts the `opencode` command,
+# then wraps the real binary with post-session memory extraction.
 #
-# Usage:
-#   opencode [any opencode args...]
+# Subcommands:
+#   opencode-memory install    — Install shell hook to ~/.zshrc or ~/.bashrc
+#   opencode-memory uninstall  — Remove shell hook
+#   opencode-memory [args...]  — Run opencode with memory extraction
 #
 # How it works:
-#   1. Finds the real `opencode` binary (skipping this wrapper in PATH)
-#   2. Runs it normally with all your arguments
-#   3. After you exit, finds the most recent session
-#   4. Forks that session and sends a memory extraction prompt
-#   5. The extraction runs in the background so you're not blocked
+#   1. Shell hook defines `opencode()` function that delegates to `opencode-memory`
+#   2. `opencode-memory` finds the real `opencode` binary in PATH
+#   3. Runs it normally with all your arguments
+#   4. After you exit, finds the most recent session
+#   5. Forks that session and sends a memory extraction prompt
+#   6. The extraction runs in the background so you're not blocked
 #
 # Requirements:
-#   - Real `opencode` CLI reachable in PATH (after this wrapper)
+#   - Real `opencode` CLI reachable in PATH
 #   - `jq` for JSON parsing
 #   - The opencode-memory plugin installed (provides memory_save tool)
 #
@@ -32,23 +34,93 @@
 set -euo pipefail
 
 # ============================================================================
-# Resolve the real opencode binary (skip this wrapper)
+# Shell Hook Management
 # ============================================================================
 
-SELF="$(cd "$(dirname "$0")" && pwd -P)/$(basename "$0")"
+HOOK_START_MARKER='# >>> opencode-memory auto-initialization >>>'
+HOOK_END_MARKER='# <<< opencode-memory auto-initialization <<<'
+
+detect_shell_rc() {
+  if [ -f "$HOME/.zshrc" ]; then
+    echo "$HOME/.zshrc"
+  elif [ -f "$HOME/.bashrc" ]; then
+    echo "$HOME/.bashrc"
+  else
+    echo "$HOME/.zshrc"
+  fi
+}
+
+install_hook() {
+  local rc_file
+  rc_file=$(detect_shell_rc)
+
+  if grep -qF "$HOOK_START_MARKER" "$rc_file" 2>/dev/null; then
+    echo "[opencode-memory] Hook already installed in $rc_file"
+    return 0
+  fi
+
+  cat >> "$rc_file" << 'HOOK'
+
+# >>> opencode-memory auto-initialization >>>
+opencode() {
+  command opencode-memory "$@"
+}
+# <<< opencode-memory auto-initialization <<<
+HOOK
+
+  echo "[opencode-memory] Shell hook installed in $rc_file"
+  echo "[opencode-memory] Restart your shell or run: source $rc_file"
+}
+
+uninstall_hook() {
+  local rc_file
+  rc_file=$(detect_shell_rc)
+
+  if ! grep -qF "$HOOK_START_MARKER" "$rc_file" 2>/dev/null; then
+    echo "[opencode-memory] Hook not found in $rc_file"
+    return 0
+  fi
+
+  local tmp_file
+  tmp_file=$(mktemp)
+  awk -v start="$HOOK_START_MARKER" -v end="$HOOK_END_MARKER" '
+    $0 == start { skip=1; next }
+    $0 == end   { skip=0; next }
+    !skip
+  ' "$rc_file" > "$tmp_file"
+
+  mv "$tmp_file" "$rc_file"
+  echo "[opencode-memory] Shell hook removed from $rc_file"
+  echo "[opencode-memory] Restart your shell or run: source $rc_file"
+}
+
+# Handle subcommands before any opencode resolution
+case "${1:-}" in
+  install)
+    install_hook
+    exit 0
+    ;;
+  uninstall)
+    uninstall_hook
+    exit 0
+    ;;
+esac
+
+# ============================================================================
+# Resolve the real opencode binary
+# ============================================================================
 
 find_real_opencode() {
-  local IFS=':'
-  for dir in $PATH; do
-    local candidate="$dir/opencode"
-    if [ -x "$candidate" ] && [ "$(cd "$(dirname "$candidate")" && pwd -P)/$(basename "$candidate")" != "$SELF" ]; then
-      echo "$candidate"
-      return 0
-    fi
-  done
-  echo "[opencode-memory] ERROR: Cannot find real opencode binary in PATH" >&2
-  echo "[opencode-memory] Make sure opencode is installed and this wrapper is placed earlier in PATH" >&2
-  exit 1
+  # Since this script is named `opencode-memory` (not `opencode`),
+  # `command -v opencode` finds the real binary without ambiguity.
+  local real
+  real=$(command -v opencode 2>/dev/null) || true
+  if [ -z "$real" ] || [ ! -x "$real" ]; then
+    echo "[opencode-memory] ERROR: Cannot find opencode binary in PATH" >&2
+    echo "[opencode-memory] Make sure opencode is installed: https://opencode.ai" >&2
+    exit 1
+  fi
+  echo "$real"
 }
 
 REAL_OPENCODE="$(find_real_opencode)"
@@ -129,15 +201,15 @@ has_new_memories() {
   # Check if any memory file was modified during the session
   # Checks all projects' memory directories for files newer than the timestamp marker
   local mem_base="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects"
-  
+
   if [ ! -d "$mem_base" ]; then
     return 1
   fi
-  
+
   # Find any .md file under projects/*/memory/ newer than our timestamp
   local newer_files
   newer_files=$(find "$mem_base" -path "*/memory/*.md" -newer "$TIMESTAMP_FILE" 2>/dev/null | head -1)
-  
+
   [ -n "$newer_files" ]
 }
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Cross-session memory plugin for OpenCode — Claude Code compatible, persistent, file-based memory",
   "main": "src/index.ts",
   "bin": {
-    "opencode": "./bin/opencode"
+    "opencode-memory": "./bin/opencode-memory"
   },
   "exports": {
     ".": "./src/index.ts"


### PR DESCRIPTION
## Summary

- Rename `bin/opencode` → `bin/opencode-memory` to eliminate name collision with the real opencode binary
- Add `opencode-memory install` / `uninstall` subcommands that write/remove a shell function hook in `~/.zshrc` or `~/.bashrc`
- Shell functions have higher priority than PATH binaries, so this approach is robust regardless of PATH ordering (fixes the issue where `~/.opencode/bin` comes before nvm bin in PATH)
- Simplify `find_real_opencode()` — since the script is no longer named `opencode`, `command -v opencode` finds the real binary directly without self-skipping logic

## Test plan

- [ ] `npm install -g .` installs `opencode-memory` CLI to nvm bin
- [ ] `opencode-memory install` appends shell hook to `~/.zshrc`
- [ ] After `source ~/.zshrc`, running `opencode` invokes the wrapper
- [ ] `opencode-memory uninstall` cleanly removes the hook block
- [ ] Idempotent: running `install` twice does not duplicate the hook
- [ ] `alias oc=opencode` continues to work through the shell function

🤖 Generated with [Claude Code](https://claude.com/claude-code)