### PR TITLE
feat: add self version command

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ opencode-memory uninstall   # removes shell hook from .zshrc/.bashrc
 npm uninstall -g opencode-claude-memory
 ```
 
+To print the wrapper package version:
+
+```bash
+opencode-memory self -v
+```
+
 This removes the shell hook, the CLI, and the plugin. Your saved memories in `~/.claude/projects/` are **not** deleted.
 
 ## 💡 Why this exists

--- a/bin/opencode-memory
+++ b/bin/opencode-memory
@@ -8,6 +8,7 @@
 # Subcommands:
 #   opencode-memory install    — Install shell hook to ~/.zshrc or ~/.bashrc
 #   opencode-memory uninstall  — Remove shell hook
+#   opencode-memory self -v    — Print the wrapper package version
 #   opencode-memory [args...]  — Run opencode with post-session memory maintenance
 #
 # How it works:
@@ -38,6 +39,22 @@
 #
 
 set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+PACKAGE_JSON="$SCRIPT_DIR/../package.json"
+
+print_wrapper_version() {
+  local version
+
+  version=$(awk -F'"' '/^[[:space:]]*"version"[[:space:]]*:/ { print $4; exit }' "$PACKAGE_JSON")
+
+  if [ -z "$version" ]; then
+    echo "[opencode-memory] ERROR: Cannot read package version from $PACKAGE_JSON" >&2
+    exit 1
+  fi
+
+  printf '%s\n' "$version"
+}
 
 # ============================================================================
 # Shell Hook Management
@@ -137,6 +154,14 @@ case "${1:-}" in
   uninstall)
     uninstall_hook
     exit 0
+    ;;
+  self)
+    case "${2:-}" in
+      -v|--version|version)
+        print_wrapper_version
+        exit 0
+        ;;
+    esac
     ;;
 esac
 


### PR DESCRIPTION
## Summary
- add `opencode-memory self -v`, `self --version`, and `self version` so the wrapper can report its own package version
- keep top-level `opencode-memory -v` delegated to the real `opencode` binary
- document the wrapper-specific version command in the README

## Validation
- `bash -n bin/opencode-memory`
- run `opencode-memory self -v` with a fake `opencode` binary in `PATH`
- run `opencode-memory -v` with a fake `opencode` binary in `PATH`