### PR TITLE
fix: use stable per-project tmp log directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Yes. Set `OPENCODE_MEMORY_AUTODREAM=0`. You can also tune gates with:
 
 ### Logs
 
-Logs are written to `$TMPDIR/opencode-memory-logs/`:
+Logs are written to `/tmp/opencode-claude-memory/<project-hash>/`:
 - `extract-*.log`: automatic memory extraction
 - `dream-*.log`: auto-dream consolidation
 

--- a/bin/opencode-memory
+++ b/bin/opencode-memory
@@ -204,13 +204,7 @@ AUTODREAM_STALE_LOCK_SECS=$((60 * 60))
 
 WORKING_DIR="${OPENCODE_MEMORY_DIR:-$(pwd)}"
 
-TMP_BASE_DIR="${TMPDIR:-/tmp}"
-while [ "$TMP_BASE_DIR" != "/" ] && [ "${TMP_BASE_DIR%/}" != "$TMP_BASE_DIR" ]; do
-  TMP_BASE_DIR="${TMP_BASE_DIR%/}"
-done
-if [ -z "$TMP_BASE_DIR" ]; then
-  TMP_BASE_DIR="/"
-fi
+LOG_BASE_DIR="/tmp/opencode-claude-memory"
 
 # Scope lock files at project root granularity (not per-subdirectory).
 PROJECT_SCOPE_DIR="$WORKING_DIR"
@@ -221,7 +215,7 @@ fi
 PROJECT_KEY="$(printf '%s' "$PROJECT_SCOPE_DIR" | cksum | awk '{print $1}')"
 
 # Lock files (prevent concurrent work on the same project)
-LOCK_DIR="$TMP_BASE_DIR/opencode-memory-locks"
+LOCK_DIR="/tmp/opencode-memory-locks"
 mkdir -p "$LOCK_DIR"
 EXTRACT_LOCK_FILE="$LOCK_DIR/${PROJECT_KEY}.extract.lock"
 
@@ -230,7 +224,7 @@ mkdir -p "$STATE_DIR"
 CONSOLIDATION_LOCK_FILE="$STATE_DIR/${PROJECT_KEY}.consolidate-lock"
 
 # Logs
-LOG_DIR="$TMP_BASE_DIR/opencode-memory-logs"
+LOG_DIR="$LOG_BASE_DIR/${PROJECT_KEY}"
 mkdir -p "$LOG_DIR"
 TASK_LOG_PREFIX="$(date +%Y%m%d-%H%M%S)-${PROJECT_KEY}"
 EXTRACT_LOG_FILE="$LOG_DIR/extract-${TASK_LOG_PREFIX}.log"

--- a/test/opencode-memory.test.ts
+++ b/test/opencode-memory.test.ts
@@ -1,10 +1,11 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { chmodSync, existsSync, mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "fs"
+import { chmodSync, existsSync, mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "fs"
 import { tmpdir } from "os"
-import { join } from "path"
+import { dirname, join } from "path"
 import { spawnSync } from "child_process"
 
 const tempRoots: string[] = []
+const tempLogDirs = new Set<string>()
 const scriptPath = join(process.cwd(), "bin", "opencode-memory")
 
 function makeTempRoot(): string {
@@ -18,6 +19,26 @@ function writeExecutable(filePath: string, content: string): void {
   chmodSync(filePath, 0o755)
 }
 
+function rememberLogDirFromPath(logPath: string): void {
+  tempLogDirs.add(dirname(logPath))
+}
+
+function findRecentExtractLog(startedAt: number): string {
+  const logRoot = join("/tmp", "opencode-claude-memory")
+  const projectDirs = readdirSync(logRoot).map((entry) => join(logRoot, entry))
+
+  const extractLogs = projectDirs.flatMap((dir) =>
+    readdirSync(dir)
+      .filter((name) => name.startsWith("extract-"))
+      .map((name) => join(dir, name)),
+  )
+
+  const recentLog = extractLogs.find((logPath) => statSync(logPath).mtimeMs >= startedAt)
+  expect(recentLog).toBeDefined()
+
+  return recentLog ?? ""
+}
+
 afterEach(() => {
   while (tempRoots.length > 0) {
     const root = tempRoots.pop()
@@ -25,10 +46,15 @@ afterEach(() => {
       rmSync(root, { recursive: true, force: true })
     }
   }
+
+  for (const logDir of tempLogDirs) {
+    rmSync(logDir, { recursive: true, force: true })
+  }
+  tempLogDirs.clear()
 })
 
 describe("opencode-memory wrapper", () => {
-  test("normalizes TMPDIR before composing extraction log paths", () => {
+  test("writes extraction logs under a stable per-project /tmp directory", () => {
     const root = makeTempRoot()
     const fakeBin = join(root, "bin")
     const homeDir = join(root, "home")
@@ -60,6 +86,7 @@ exit 0
 `,
     )
 
+    const startedAt = Date.now()
     const result = spawnSync("bash", [scriptPath, "--help"], {
       cwd: root,
       encoding: "utf-8",
@@ -82,7 +109,10 @@ exit 0
     expect(logPathMatch).not.toBeNull()
 
     const logPath = logPathMatch?.[1].trim() ?? ""
-    expect(logPath.startsWith(join(root, "tmp", "opencode-memory-logs", "extract-"))).toBe(true)
+    rememberLogDirFromPath(logPath)
+    expect(logPath).toMatch(/^\/tmp\/opencode-claude-memory\/[^/]+\/extract-/)
+    expect(statSync(logPath).mtimeMs).toBeGreaterThanOrEqual(startedAt)
+    expect(logPath).toContain("/extract-")
     expect(existsSync(logPath)).toBe(true)
     expect(readFileSync(logPath, "utf-8")).toContain("extraction ok")
   })
@@ -119,6 +149,7 @@ exit 0
 `,
     )
 
+    const startedAt = Date.now()
     const result = spawnSync("bash", [scriptPath, "--help"], {
       cwd: root,
       encoding: "utf-8",
@@ -137,11 +168,8 @@ exit 0
     expect(result.status).toBe(0)
     expect(result.stderr).toBe("")
 
-    const logDir = join(root, "tmp", "opencode-memory-logs")
-    const logFiles = readdirSync(logDir)
-    expect(logFiles).toHaveLength(1)
-
-    const logPath = join(logDir, logFiles[0] ?? "")
+    const logPath = findRecentExtractLog(startedAt)
+    rememberLogDirFromPath(logPath)
     expect(readFileSync(logPath, "utf-8")).toContain("extraction ok")
   })
 })


### PR DESCRIPTION
## Summary
- write maintenance logs under `/tmp/opencode-claude-memory/<project-hash>/` so each project gets a stable, easy-to-find log directory
- keep the wrapper regression tests aligned with the new log layout and verify logs are still written when terminal output is suppressed
- update the README log location docs to match the wrapper behavior

## Testing
- bun test test/opencode-memory.test.ts