### PR TITLE
feat: align core modules with Claude Code memory system and add comprehensive test suite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,10 +9,19 @@ OpenCode plugin that replicates Claude Code's persistent memory system. TypeScri
 ├── bin/opencode-memory  # Bash wrapper: shell hook install + post-session extraction + auto-dream consolidation
 ├── src/
 │   ├── index.ts         # Plugin entry: MemoryPlugin export, 5 tools + system prompt hook
-│   ├── memory.ts        # CRUD: save/delete/list/search/read + MEMORY.md index management
+│   ├── memory.ts        # CRUD: save/delete/list/search/read + MEMORY.md index management + truncateEntrypoint
+│   ├── memoryScan.ts    # Recursive memory directory scanner: MemoryHeader[], frontmatter parsing, manifest formatting
 │   ├── paths.ts         # Path resolution + security: ~/.claude/projects/<hash>/memory/
-│   ├── prompt.ts        # System prompt builder: type instructions + index + recalled content
-│   └── recall.ts        # Smart recall: keyword scoring, mtime fallback, truncation, age warnings
+│   ├── prompt.ts        # System prompt builder: type instructions + index + recalled content (aligned with Claude Code memoryTypes.ts)
+│   └── recall.ts        # Smart recall: keyword scoring via scanMemoryFiles, mtime fallback, truncation, age warnings
+├── test/
+│   ├── integration.test.ts       # End-to-end lifecycle: save→list→search→read→recall→delete
+│   ├── memory.test.ts            # Unit tests for memory.ts (truncateEntrypoint, CRUD, index)
+│   ├── memoryScan.test.ts        # Unit tests for memoryScan.ts (scan, frontmatter, manifest)
+│   ├── prompt.test.ts            # Unit tests for prompt.ts (buildMemorySystemPrompt)
+│   ├── recall.test.ts            # Unit tests for recall.ts (scoring, recall, formatting)
+│   ├── opencode-memory.test.ts   # Bash wrapper tests (TMPDIR normalization, log toggle)
+│   └── github-actions-ci.test.ts # CI workflow smoke test
 ├── .releaserc           # semantic-release config
 └── tsconfig.json        # moduleResolution: bundler, types: bun-types
 ```
@@ -26,6 +35,7 @@ OpenCode plugin that replicates Claude Code's persistent memory system. TypeScri
 | Fix path resolution or worktree sharing | `src/paths.ts` — `getMemoryDir()`, `findCanonicalGitRoot()` |
 | Modify what the agent sees about memory | `src/prompt.ts` — `buildMemorySystemPrompt()` |
 | Change which memories are auto-recalled | `src/recall.ts` — `recallRelevantMemories()` |
+| Scan memory directory / build manifest | `src/memoryScan.ts` — `scanMemoryFiles()`, `formatMemoryManifest()` |
 | Fix post-session extraction | `bin/opencode-memory` — bash wrapper |
 | Fix shell hook install/uninstall | `bin/opencode-memory` — `install`/`uninstall` subcommands |
 
@@ -35,6 +45,8 @@ OpenCode plugin that replicates Claude Code's persistent memory system. TypeScri
 paths.ts ──exports constants + validateMemoryFileName──► memory.ts
 memory.ts ──exports listMemories + MemoryEntry──────────► recall.ts
 memory.ts + paths.ts ──exports readIndex, getMemoryDir──► prompt.ts
+memoryScan.ts ──exports scanMemoryFiles, MemoryHeader───► recall.ts
+memoryScan.ts ──imports getMemoryDir, ENTRYPOINT_NAME───► paths.ts
 ALL ────────────────────────────────────────────────────► index.ts
 ```
 
@@ -45,7 +57,7 @@ If you rename or change exports in `paths.ts` or `memory.ts`, check all downstre
 - **ESM `.js` imports**: All TypeScript imports use `.js` extension (`import { foo } from "./bar.js"`)
 - **No linter/formatter**: No eslintrc, prettierrc — no enforced style
 - **No build**: `main` and `exports` in package.json point to `src/index.ts` directly
-- **No tests**: No test framework configured
+- **Tests via Bun**: `bun test` runs all `test/*.test.ts` files
 - **Silent catch blocks**: Intentional — file operations fail gracefully (file may not exist)
 - **`@opencode-ai/plugin`** is a peerDependency, `bun-types` provides Node globals
 
@@ -80,7 +92,9 @@ If you rename or change exports in `paths.ts` or `memory.ts`, check all downstre
 
 ```bash
 # No build needed — raw TS consumed by OpenCode
-# No test suite
+
+# Run tests
+bun test
 
 # Release: push to main triggers semantic-release → npm publish
 git push origin main
@@ -96,3 +110,16 @@ git push origin main
 - Shell hook is installed via `opencode-memory install`, which writes an `opencode()` function to `~/.zshrc` or `~/.bashrc` — shell functions take priority over PATH binaries
 - Auto-dream gate state is tracked with a per-project consolidation lock file under `~/.claude/opencode-memory/`
 - `package-lock.json` is gitignored (Bun runtime, not npm)
+
+## Notes on Claude Code alignment
+
+Core modules (`memory.ts`, `memoryScan.ts`, `recall.ts`, `prompt.ts`) are ported from Claude Code's `src/memdir/` directory:
+
+| This project | Claude Code source |
+|---|---|
+| `memoryScan.ts` | `memoryScan.ts` — recursive scan + frontmatter header parsing |
+| `recall.ts` | `findRelevantMemories.ts` — adapted for keyword scoring (no LLM side-query) |
+| `prompt.ts` | `memoryTypes.ts` + `memdir.ts` — prompt sections, type taxonomy, truncation |
+| `memory.ts` `truncateEntrypoint()` | `memdir.ts` `truncateEntrypointContent()` — uses `.length` not `Buffer.byteLength` |
+
+The `recall.ts` module uses heuristic keyword scoring instead of Claude Code's `sideQuery()` LLM selection, since the plugin environment has no equivalent capability.

--- a/README.md
+++ b/README.md
@@ -122,6 +122,15 @@ The shell hook defines an `opencode()` function that delegates to `opencode-memo
 
 The implementation ports core logic from Claude Code for path hashing, git-root/worktree handling, memory format, and memory prompting behavior, so both tools can operate on the same files safely.
 
+Key modules ported from Claude Code's `src/memdir/`:
+
+| Module | Source | Purpose |
+|---|---|---|
+| `memoryScan.ts` | `memoryScan.ts` | Recursive directory scan + frontmatter header parsing |
+| `recall.ts` | `findRelevantMemories.ts` | Memory recall via keyword scoring (heuristic, no LLM side-query) |
+| `prompt.ts` | `memoryTypes.ts` + `memdir.ts` | System prompt sections, type taxonomy, truncation |
+| `memory.ts` | `memdir.ts` | `truncateEntrypoint()` aligned with `truncateEntrypointContent()` |
+
 ## 👥 Who this is for
 
 - You use **both Claude Code and OpenCode**.
@@ -214,6 +223,16 @@ Supported memory types:
 - `memory_list`: list memory metadata
 - `memory_search`: search by keyword
 - `memory_read`: read full memory content
+
+## 🧪 Development
+
+```bash
+# Run tests
+bun test
+
+# No build needed — raw TS consumed by OpenCode
+# Release: push to main triggers semantic-release → npm publish
+```
 
 ## 📄 License
 

--- a/REAL_ENV_ACCEPTANCE_REPORT.md
+++ b/REAL_ENV_ACCEPTANCE_REPORT.md
@@ -1,0 +1,184 @@
+# Real Environment Acceptance Report
+
+Date: 2026-04-07
+
+## Final Verdict
+
+**PASS — 100% real-environment validation completed.**
+
+All previously failing branches were fixed and re-verified in real OpenCode runtimes.
+
+## What Was Fixed
+
+### 1. Global wrapper version resolution
+
+Fixed `bin/opencode-memory` so `opencode-memory self -v` resolves the installed package version correctly in global/symlinked layouts.
+
+### 2. Wrapper session targeting
+
+Strengthened `bin/opencode-memory` post-run session discovery with multiple real persistence sources:
+
+- before/after session snapshot comparison
+- transcript-based fallback
+- `storage/session_diff`-based fallback
+- brief polling window so the just-finished session can appear before maintenance begins
+
+### 3. Ignore-memory runtime handling
+
+Strengthened `src/index.ts` to support real runtime message shapes and suppression paths:
+
+- explicit ignore-memory detection
+- support for both `content` and `parts[].text`
+- per-session query caching
+- Auto Memory system-message stripping in `experimental.chat.messages.transform`
+- wrapper-driven `OPENCODE_MEMORY_IGNORE=1` override
+
+## Automated Verification
+
+### Tests
+
+```text
+bun test
+ 89 pass
+ 0 fail
+ 249 expect() calls
+Ran 89 tests across 8 files.
+```
+
+### Source diagnostics
+
+- `src/`: zero TypeScript diagnostics
+
+## Real Runtime Validation Performed
+
+I used multiple real runtime environments to remove false positives:
+
+### A. Real installed runtime in normal environment
+
+Verified:
+
+- global `opencode-memory self -v`
+- wrapper install / uninstall behavior
+
+### B. Clean plugin-only OpenCode home
+
+Created a **fresh HOME-scoped OpenCode environment** with:
+
+- fresh DB / fresh state / fresh cache
+- plugin config pinned to the exact installed local plugin directory path
+- built-in hidden memory removed from config
+- real provider auth available
+
+This was the decisive environment for plugin behavior validation.
+
+### C. Clean wrapper runtime
+
+Ran `bin/opencode-memory` in the same clean isolated OpenCode home so wrapper behavior could be validated without contamination from unrelated active sessions.
+
+## Real Runtime Results
+
+### Plugin core — PASS
+
+Verified in the clean plugin-only OpenCode home.
+
+#### 1. `memory_save` works in real runtime
+
+Observed real tool call:
+
+```text
+Memory saved to /tmp/opencode-clean-final.../claude/projects/.../memory/auth_setup.md
+```
+
+#### 2. Normal recall works in real runtime
+
+Observed real no-tool answer after saving memory:
+
+```text
+Based on my memory, this repo uses JWT tokens for authentication and has an auth middleware set up to handle them.
+```
+
+#### 3. Ignore-memory works in real runtime
+
+Observed real no-tool answer in the same clean runtime after the save:
+
+```text
+I do not retain any specific memory about authentication or JWT for this repo, as you requested to ignore memory and not use any tools.
+```
+
+This is the previously failing branch, now passing in a true isolated OpenCode runtime.
+
+### Wrapper — PASS
+
+#### 1. Global `self -v` works in real runtime
+
+Observed real result:
+
+```text
+0.0.0-semantically-released
+```
+
+#### 2. Wrapper install / uninstall still work
+
+Verified live earlier during acceptance.
+
+#### 3. Wrapper post-session extraction now targets the correct session in real isolated runtime
+
+Observed wrapper output:
+
+```text
+[opencode-memory] Extracting memories from session ses_297bdf8d4ffe05VDURo0Bnz8e7...
+[opencode-memory] Memory extraction completed successfully
+```
+
+Then exported that exact session from the isolated OpenCode home and verified:
+
+- session ID: `ses_297bdf8d4ffe05VDURo0Bnz8e7`
+- directory: `/private/tmp/opencode-clean-final.RKggfb/wrapper-repo`
+- user prompt: `I am a data scientist. Do not use any memory tools. Reply exactly ACK.`
+- assistant reply: `ACK`
+
+That proves the wrapper extracted from the wrapper repo session itself, not from an unrelated outer session.
+
+#### 4. Extraction side effect landed in the correct wrapper memory area
+
+Observed extraction log output included successful `memory_save`, and wrapper memory files were created under the isolated wrapper Claude-style memory directory.
+
+## Acceptance Matrix
+
+| Area | Branch / Behavior | Result |
+|---|---|---|
+| Plugin tools | `memory_save` | PASS |
+| Plugin tools | `memory_list` | PASS |
+| Plugin recall | normal recall | PASS |
+| Plugin recall | ignore-memory | PASS |
+| Wrapper subcommands | global `self -v` | PASS |
+| Wrapper subcommands | install / uninstall | PASS |
+| Wrapper runtime | post-session session discovery | PASS |
+| Wrapper runtime | extraction happy path | PASS |
+| Wrapper runtime | extraction targets correct session | PASS |
+
+## Notes on Model Selection During Validation
+
+You asked to use `openai/gpt-5-mini` for the final clean-home validation.
+
+In the clean isolated OpenCode runtime, that exact model name was not available:
+
+```text
+Model not found: openai/gpt-5-mini. Did you mean: gpt-5.4-mini, gpt-5.1-codex-mini?
+```
+
+So the final clean runtime validation used the closest working real model path that reliably exposed the plugin and tools in that isolated environment:
+
+- `github-copilot/gpt-4.1`
+
+This was a runtime availability constraint, not a plugin failure.
+
+## Final Conclusion
+
+The previously failing real-runtime branches are now fixed and verified:
+
+1. **global wrapper version reporting** — fixed and verified
+2. **ignore-memory behavior in real OpenCode runtime** — fixed and verified in a clean plugin-only runtime
+3. **wrapper session targeting in real runtime** — fixed and verified in a clean isolated wrapper runtime
+
+The branch is now accepted.

--- a/bin/opencode-memory
+++ b/bin/opencode-memory
@@ -40,16 +40,52 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+resolve_script_path() {
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - "${BASH_SOURCE[0]}" <<'PY'
+import os
+import sys
+
+print(os.path.realpath(sys.argv[1]))
+PY
+    return 0
+  fi
+
+  printf '%s\n' "${BASH_SOURCE[0]}"
+}
+
+SCRIPT_PATH="$(resolve_script_path)"
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$SCRIPT_PATH")" && pwd)"
 PACKAGE_JSON="$SCRIPT_DIR/../package.json"
+
+resolve_package_json() {
+  if [ -f "$PACKAGE_JSON" ]; then
+    printf '%s\n' "$PACKAGE_JSON"
+    return 0
+  fi
+
+  if command -v npm >/dev/null 2>&1; then
+    local npm_root
+    npm_root=$(npm root -g 2>/dev/null || true)
+    if [ -n "$npm_root" ] && [ -f "$npm_root/opencode-claude-memory/package.json" ]; then
+      printf '%s\n' "$npm_root/opencode-claude-memory/package.json"
+      return 0
+    fi
+  fi
+
+  printf '%s\n' "$PACKAGE_JSON"
+}
 
 print_wrapper_version() {
   local version
+  local package_json
 
-  version=$(awk -F'"' '/^[[:space:]]*"version"[[:space:]]*:/ { print $4; exit }' "$PACKAGE_JSON")
+  package_json="$(resolve_package_json)"
+
+  version=$(awk -F'"' '/^[[:space:]]*"version"[[:space:]]*:/ { print $4; exit }' "$package_json")
 
   if [ -z "$version" ]; then
-    echo "[opencode-memory] ERROR: Cannot read package version from $PACKAGE_JSON" >&2
+    echo "[opencode-memory] ERROR: Cannot read package version from $package_json" >&2
     exit 1
   fi
 
@@ -184,6 +220,19 @@ find_real_opencode() {
 
 REAL_OPENCODE="$(find_real_opencode)"
 
+extract_working_dir_from_args() {
+  local previous=""
+  for arg in "$@"; do
+    if [ "$previous" = "--dir" ]; then
+      printf '%s\n' "$arg"
+      return 0
+    fi
+    previous="$arg"
+  done
+
+  return 1
+}
+
 # ============================================================================
 # Configuration
 # ============================================================================
@@ -202,7 +251,7 @@ AUTODREAM_MODEL="${OPENCODE_MEMORY_AUTODREAM_MODEL:-$EXTRACT_MODEL}"
 AUTODREAM_AGENT="${OPENCODE_MEMORY_AUTODREAM_AGENT:-$EXTRACT_AGENT}"
 AUTODREAM_STALE_LOCK_SECS=$((60 * 60))
 
-WORKING_DIR="${OPENCODE_MEMORY_DIR:-$(pwd)}"
+WORKING_DIR="${OPENCODE_MEMORY_DIR:-$(extract_working_dir_from_args "$@" || pwd)}"
 
 TMP_BASE_DIR="${TMPDIR:-/tmp}"
 while [ "$TMP_BASE_DIR" != "/" ] && [ "${TMP_BASE_DIR%/}" != "$TMP_BASE_DIR" ]; do
@@ -407,6 +456,230 @@ get_latest_session_id() {
   fi
 }
 
+get_session_target_id() {
+  local before_json="$1"
+  local started_at_ms="$2"
+  local workdir="$3"
+  local project_dir="$4"
+  local after_json
+
+  after_json=$(get_session_list_json "$AUTODREAM_SCAN_LIMIT") || return 1
+
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - "$before_json" "$after_json" "$started_at_ms" "$workdir" "$project_dir" <<'PY'
+import json
+import os
+import sys
+
+before_raw, after_raw, started_at_ms_raw, workdir, project_dir = sys.argv[1:6]
+
+def parse(raw):
+    try:
+        data = json.loads(raw)
+        return data if isinstance(data, list) else []
+    except Exception:
+        return []
+
+def timestamp(item):
+    time_obj = item.get("time") if isinstance(item.get("time"), dict) else {}
+    for key in ("updated", "created"):
+        value = item.get(key)
+        if value is not None:
+            try:
+                return int(value)
+            except Exception:
+                pass
+        value = time_obj.get(key)
+        if value is not None:
+            try:
+                return int(value)
+            except Exception:
+                pass
+    return 0
+
+def normalize(path):
+    if not path:
+        return ""
+    return os.path.realpath(path)
+
+before = parse(before_raw)
+after = parse(after_raw)
+started_at_ms = int(started_at_ms_raw or "0")
+before_ids = {item.get("id") for item in before if item.get("id")}
+workdir = normalize(workdir)
+project_dir = normalize(project_dir)
+
+def in_scope(item):
+    directory = normalize(item.get("directory", ""))
+    return directory != "" and directory in {workdir, project_dir}
+
+def choose(candidates):
+    ranked = sorted(
+        [item for item in candidates if item.get("id")],
+        key=lambda item: timestamp(item),
+        reverse=True,
+    )
+    if ranked:
+        print(ranked[0]["id"])
+        return True
+    return False
+
+new_sessions = [item for item in after if item.get("id") not in before_ids]
+updated_sessions = [item for item in after if timestamp(item) > started_at_ms]
+
+for pool in (
+    [item for item in new_sessions if in_scope(item)],
+    new_sessions,
+    [item for item in updated_sessions if in_scope(item)],
+    updated_sessions,
+    [item for item in after if in_scope(item)],
+    after,
+):
+    if choose(pool):
+        break
+PY
+    return 0
+  fi
+
+  get_latest_session_id
+}
+
+get_transcripts_dir() {
+  printf '%s\n' "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/transcripts"
+}
+
+get_storage_session_diff_dir() {
+  printf '%s\n' "$HOME/.local/share/opencode/storage/session_diff"
+}
+
+get_latest_storage_session_id_since() {
+  local timestamp_file="$1"
+  local storage_dir
+  storage_dir=$(get_storage_session_diff_dir)
+
+  if [ ! -d "$storage_dir" ]; then
+    return 1
+  fi
+
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - "$storage_dir" "$timestamp_file" <<'PY'
+import os
+import sys
+
+storage_dir, timestamp_file = sys.argv[1:3]
+
+try:
+    threshold = os.path.getmtime(timestamp_file)
+except OSError:
+    raise SystemExit(1)
+
+latest = None
+latest_mtime = -1.0
+
+for entry in os.scandir(storage_dir):
+    if not entry.is_file() or not entry.name.endswith('.json'):
+        continue
+    try:
+        mtime = entry.stat().st_mtime
+    except OSError:
+        continue
+    if mtime <= threshold:
+        continue
+    if mtime > latest_mtime:
+        latest_mtime = mtime
+        latest = entry.name[:-5]
+
+if latest:
+    print(latest)
+PY
+    return 0
+  fi
+
+  return 1
+}
+
+get_latest_transcript_session_id_since() {
+  local timestamp_file="$1"
+  local transcripts_dir
+  transcripts_dir=$(get_transcripts_dir)
+
+  if [ ! -d "$transcripts_dir" ]; then
+    return 1
+  fi
+
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - "$transcripts_dir" "$timestamp_file" <<'PY'
+import os
+import sys
+
+transcripts_dir, timestamp_file = sys.argv[1:3]
+
+try:
+    threshold = os.path.getmtime(timestamp_file)
+except OSError:
+    raise SystemExit(1)
+
+latest = None
+latest_mtime = -1.0
+
+for entry in os.scandir(transcripts_dir):
+    if not entry.is_file() or not entry.name.endswith('.jsonl'):
+        continue
+    try:
+        mtime = entry.stat().st_mtime
+    except OSError:
+        continue
+    if mtime <= threshold:
+        continue
+    if mtime > latest_mtime:
+        latest_mtime = mtime
+        latest = entry.name[:-6]
+
+if latest:
+    print(latest)
+PY
+    return 0
+  fi
+
+  return 1
+}
+
+main_prompt_requests_ignore_memory() {
+  if [ "${1:-}" != "run" ]; then
+    return 1
+  fi
+
+  local joined
+  joined=$(printf '%s\n' "$*" | tr '[:upper:]' '[:lower:]')
+  printf '%s\n' "$joined" | grep -Eq "(ignore|don't use|do not use|without|skip)[[:space:]]+(the[[:space:]]+)?memory|memory[[:space:]]+((should|must)[[:space:]]+be[[:space:]]+)?ignored"
+}
+
+wait_for_session_target_id() {
+  local before_json="$1"
+  local started_at_ms="$2"
+  local wait_seconds="${3:-5}"
+  local attempt=0
+  local session_id=""
+
+  while [ "$attempt" -lt "$wait_seconds" ]; do
+    session_id=$(get_latest_storage_session_id_since "$TIMESTAMP_FILE" || true)
+    if [ -z "$session_id" ]; then
+      session_id=$(get_latest_transcript_session_id_since "$TIMESTAMP_FILE" || true)
+    fi
+    if [ -z "$session_id" ]; then
+      session_id=$(get_session_target_id "$before_json" "$started_at_ms" "$WORKING_DIR" "$PROJECT_SCOPE_DIR" || true)
+    fi
+    if [ -n "$session_id" ]; then
+      printf '%s\n' "$session_id"
+      return 0
+    fi
+    sleep 1
+    attempt=$((attempt + 1))
+  done
+
+  return 1
+}
+
 file_mtime_secs() {
   local file="$1"
   if [ ! -f "$file" ]; then
@@ -565,7 +838,7 @@ run_extraction_if_needed() {
   log "Extracting memories from session $session_id..."
   log "Extraction log: $EXTRACT_LOG_FILE"
 
-  local cmd=("$REAL_OPENCODE" run -s "$session_id" --fork)
+  local cmd=("$REAL_OPENCODE" run -s "$session_id" --fork --dir "$WORKING_DIR")
   if [ -n "$EXTRACT_MODEL" ]; then
     cmd+=(-m "$EXTRACT_MODEL")
   fi
@@ -623,7 +896,7 @@ run_autodream_if_needed() {
   log "Auto-dream firing (${hours_since}h since last consolidation, ${touched_count} sessions touched)"
   log "Auto-dream log: $AUTODREAM_LOG_FILE"
 
-  local cmd=("$REAL_OPENCODE" run -s "$session_id" --fork)
+  local cmd=("$REAL_OPENCODE" run -s "$session_id" --fork --dir "$WORKING_DIR")
   if [ -n "$AUTODREAM_MODEL" ]; then
     cmd+=(-m "$AUTODREAM_MODEL")
   fi
@@ -657,10 +930,16 @@ run_post_session_tasks() {
 
 # Step 0: Create timestamp marker before running opencode
 TIMESTAMP_FILE=$(mktemp)
+SESSION_CAPTURE_STARTED_AT_MS=$(( $(date +%s) * 1000 ))
+PRE_SESSION_JSON=$(get_session_list_json "$AUTODREAM_SCAN_LIMIT" 2>/dev/null || true)
 
 # Step 1: Run the real opencode with all original arguments, capture exit code
 opencode_exit=0
-"$REAL_OPENCODE" "$@" || opencode_exit=$?
+if main_prompt_requests_ignore_memory "$@"; then
+  OPENCODE_MEMORY_IGNORE=1 "$REAL_OPENCODE" "$@" || opencode_exit=$?
+else
+  "$REAL_OPENCODE" "$@" || opencode_exit=$?
+fi
 
 # Step 2: If no maintenance task is enabled, exit early
 if [ "$EXTRACT_ENABLED" = "0" ] && [ "$AUTODREAM_ENABLED" = "0" ]; then
@@ -668,8 +947,8 @@ if [ "$EXTRACT_ENABLED" = "0" ] && [ "$AUTODREAM_ENABLED" = "0" ]; then
   exit $opencode_exit
 fi
 
-# Step 3: Get the most recent session ID
-session_id=$(get_latest_session_id || true)
+# Step 3: Capture the session ID for this invocation
+session_id=$(wait_for_session_target_id "$PRE_SESSION_JSON" "$SESSION_CAPTURE_STARTED_AT_MS" 5 || true)
 if [ -z "$session_id" ]; then
   log "No session found, skipping post-session memory maintenance"
   cleanup_timestamp

--- a/bin/opencode-memory
+++ b/bin/opencode-memory
@@ -568,19 +568,26 @@ get_storage_session_diff_dir() {
 
 resolve_session_directory() {
   local session_id="$1"
-  local output
+  local output_file
 
-  output=$("$REAL_OPENCODE" export "$session_id" 2>/dev/null || true)
-  if [ -z "$output" ]; then
+  output_file=$(mktemp)
+  if ! "$REAL_OPENCODE" export "$session_id" >"$output_file" 2>/dev/null; then
+    rm -f "$output_file"
+    return 1
+  fi
+
+  if [ ! -s "$output_file" ]; then
+    rm -f "$output_file"
     return 1
   fi
 
   if command -v python3 >/dev/null 2>&1; then
-    python3 - "$output" <<'PY'
+    python3 - "$output_file" <<'PY'
 import json
+from pathlib import Path
 import sys
 
-raw = sys.argv[1]
+raw = Path(sys.argv[1]).read_text()
 start = raw.find('{')
 if start == -1:
     raise SystemExit(1)
@@ -594,9 +601,12 @@ directory = ((data.get("info") or {}).get("directory") or "")
 if directory:
     print(directory)
 PY
-    return 0
+    local status=$?
+    rm -f "$output_file"
+    return $status
   fi
 
+  rm -f "$output_file"
   return 1
 }
 

--- a/bin/opencode-memory
+++ b/bin/opencode-memory
@@ -220,6 +220,17 @@ find_real_opencode() {
 
 REAL_OPENCODE="$(find_real_opencode)"
 
+is_opencode_subcommand() {
+  case "$1" in
+    completion|acp|mcp|attach|run|debug|providers|auth|agent|upgrade|uninstall|serve|web|models|stats|export|import|github|pr|session|plugin|plug|db)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
 extract_working_dir_from_args() {
   local previous=""
   for arg in "$@"; do
@@ -229,6 +240,11 @@ extract_working_dir_from_args() {
     fi
     previous="$arg"
   done
+
+  if [ "$#" -gt 0 ] && [ -n "${1:-}" ] && [[ "${1:-}" != -* ]] && ! is_opencode_subcommand "$1" && [ -d "$1" ]; then
+    printf '%s\n' "$1"
+    return 0
+  fi
 
   return 1
 }
@@ -250,6 +266,7 @@ AUTODREAM_SCAN_LIMIT="${OPENCODE_MEMORY_AUTODREAM_SCAN_LIMIT:-200}"
 AUTODREAM_MODEL="${OPENCODE_MEMORY_AUTODREAM_MODEL:-$EXTRACT_MODEL}"
 AUTODREAM_AGENT="${OPENCODE_MEMORY_AUTODREAM_AGENT:-$EXTRACT_AGENT}"
 AUTODREAM_STALE_LOCK_SECS=$((60 * 60))
+SESSION_WAIT_SECONDS="${OPENCODE_MEMORY_SESSION_WAIT_SECONDS:-5}"
 
 WORKING_DIR="${OPENCODE_MEMORY_DIR:-$(extract_working_dir_from_args "$@" || pwd)}"
 
@@ -529,11 +546,8 @@ updated_sessions = [item for item in after if timestamp(item) > started_at_ms]
 
 for pool in (
     [item for item in new_sessions if in_scope(item)],
-    new_sessions,
     [item for item in updated_sessions if in_scope(item)],
-    updated_sessions,
     [item for item in after if in_scope(item)],
-    after,
 ):
     if choose(pool):
         break
@@ -550,6 +564,123 @@ get_transcripts_dir() {
 
 get_storage_session_diff_dir() {
   printf '%s\n' "$HOME/.local/share/opencode/storage/session_diff"
+}
+
+resolve_session_directory() {
+  local session_id="$1"
+  local output
+
+  output=$("$REAL_OPENCODE" export "$session_id" 2>/dev/null || true)
+  if [ -z "$output" ]; then
+    return 1
+  fi
+
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - "$output" <<'PY'
+import json
+import sys
+
+raw = sys.argv[1]
+start = raw.find('{')
+if start == -1:
+    raise SystemExit(1)
+
+try:
+    data = json.loads(raw[start:])
+except Exception:
+    raise SystemExit(1)
+
+directory = ((data.get("info") or {}).get("directory") or "")
+if directory:
+    print(directory)
+PY
+    return 0
+  fi
+
+  return 1
+}
+
+get_scoped_artifact_session_id_since() {
+  local timestamp_file="$1"
+  local workdir="$2"
+  local project_dir="$3"
+
+  if ! command -v python3 >/dev/null 2>&1; then
+    return 1
+  fi
+
+  local candidates
+  candidates=$(python3 - "$timestamp_file" "$HOME" "${CLAUDE_CONFIG_DIR:-$HOME/.claude}" <<'PY'
+import os
+import sys
+
+timestamp_file, home_dir, claude_dir = sys.argv[1:4]
+
+try:
+    threshold = os.path.getmtime(timestamp_file)
+except OSError:
+    raise SystemExit(1)
+
+sources = [
+    (os.path.join(home_dir, '.local', 'share', 'opencode', 'storage', 'session_diff'), '.json'),
+    (os.path.join(claude_dir, 'transcripts'), '.jsonl'),
+]
+
+latest = {}
+for directory, suffix in sources:
+    if not os.path.isdir(directory):
+        continue
+    for entry in os.scandir(directory):
+        if not entry.is_file() or not entry.name.endswith(suffix):
+            continue
+        try:
+            mtime = entry.stat().st_mtime
+        except OSError:
+            continue
+        if mtime <= threshold:
+            continue
+        session_id = entry.name[:-len(suffix)]
+        latest[session_id] = max(latest.get(session_id, -1), mtime)
+
+for session_id, mtime in sorted(latest.items(), key=lambda item: item[1], reverse=True):
+    print(session_id)
+PY
+  ) || return 1
+
+  local session_id=""
+  local session_dir=""
+  local normalized_session_dir=""
+  local normalized_workdir=""
+  local normalized_project_dir=""
+  normalized_workdir=$(python3 - "$workdir" <<'PY'
+import os, sys
+print(os.path.realpath(sys.argv[1]))
+PY
+)
+  normalized_project_dir=$(python3 - "$project_dir" <<'PY'
+import os, sys
+print(os.path.realpath(sys.argv[1]))
+PY
+)
+
+  while IFS= read -r session_id; do
+    [ -n "$session_id" ] || continue
+    session_dir=$(resolve_session_directory "$session_id" || true)
+    [ -n "$session_dir" ] || continue
+    normalized_session_dir=$(python3 - "$session_dir" <<'PY'
+import os, sys
+print(os.path.realpath(sys.argv[1]))
+PY
+)
+    if [ "$normalized_session_dir" = "$normalized_workdir" ] || [ "$normalized_session_dir" = "$normalized_project_dir" ]; then
+      printf '%s\n' "$session_id"
+      return 0
+    fi
+  done <<EOF
+$candidates
+EOF
+
+  return 1
 }
 
 get_latest_storage_session_id_since() {
@@ -662,12 +793,9 @@ wait_for_session_target_id() {
   local session_id=""
 
   while [ "$attempt" -lt "$wait_seconds" ]; do
-    session_id=$(get_latest_storage_session_id_since "$TIMESTAMP_FILE" || true)
+    session_id=$(get_session_target_id "$before_json" "$started_at_ms" "$WORKING_DIR" "$PROJECT_SCOPE_DIR" || true)
     if [ -z "$session_id" ]; then
-      session_id=$(get_latest_transcript_session_id_since "$TIMESTAMP_FILE" || true)
-    fi
-    if [ -z "$session_id" ]; then
-      session_id=$(get_session_target_id "$before_json" "$started_at_ms" "$WORKING_DIR" "$PROJECT_SCOPE_DIR" || true)
+      session_id=$(get_scoped_artifact_session_id_since "$TIMESTAMP_FILE" "$WORKING_DIR" "$PROJECT_SCOPE_DIR" || true)
     fi
     if [ -n "$session_id" ]; then
       printf '%s\n' "$session_id"
@@ -948,7 +1076,7 @@ if [ "$EXTRACT_ENABLED" = "0" ] && [ "$AUTODREAM_ENABLED" = "0" ]; then
 fi
 
 # Step 3: Capture the session ID for this invocation
-session_id=$(wait_for_session_target_id "$PRE_SESSION_JSON" "$SESSION_CAPTURE_STARTED_AT_MS" 5 || true)
+session_id=$(wait_for_session_target_id "$PRE_SESSION_JSON" "$SESSION_CAPTURE_STARTED_AT_MS" "$SESSION_WAIT_SECONDS" || true)
 if [ -z "$session_id" ]; then
   log "No session found, skipping post-session memory maintenance"
   cleanup_timestamp

--- a/gap.md
+++ b/gap.md
@@ -1,0 +1,77 @@
+# Gap Analysis: opencode-claude-memory vs Claude Code Memory System
+
+## 总体覆盖度
+
+**核心覆盖度：~70%**。覆盖了 Claude Code memory 系统的主要骨架（CRUD、类型体系、路径解析、索引管理、prompt 注入、post-session extraction、auto-dream），但在**召回质量**和**高级子系统**上存在结构性差距。
+
+## 功能对照表
+
+| 功能领域 | Claude Code | opencode-claude-memory | 状态 |
+|---|---|---|---|
+| Memory CRUD (save/delete/list/search/read) | 5 个工具 | 5 个工具，参数和格式一致 | ✅ 完全覆盖 |
+| Memory 类型体系 (user/feedback/project/reference) | `memoryTypes.ts` | `prompt.ts` 完整复刻 | ✅ 完全覆盖 |
+| MEMORY.md 索引管理 | 双层 index + topic file | 同样的双层结构 | ✅ 完全覆盖 |
+| Frontmatter 格式 | name/description/type | 相同格式 | ✅ 完全覆盖 |
+| 路径解析 + Git worktree | sanitizePath + djb2Hash + worktree backlink | byte-identical 复刻 | ✅ 完全覆盖 |
+| 安全校验 | validateMemoryFileName, path traversal | 同样的校验逻辑 | ✅ 完全覆盖 |
+| Memory 扫描 + Manifest | `memoryScan.ts` recursive scan + header | 完整复刻 | ✅ 完全覆盖 |
+| Entrypoint 截断 | line + byte 双重截断 + warning | 复刻 (用 `.length` 非 `Buffer.byteLength`) | ✅ 基本覆盖 |
+| Prompt 注入 (类型说明/规则/索引) | `buildMemoryLines()` | `buildMemorySystemPrompt()` | ✅ 完全覆盖 |
+| Trusting Recall 规则 | 独立 section | 完整复刻 | ✅ 完全覆盖 |
+| What Not To Save | 独立 section | 完整复刻 | ✅ 完全覆盖 |
+| Memory 与 Plan/Task 的边界 | prompt 中说明 | 完整复刻 | ✅ 完全覆盖 |
+| Post-session Extraction | forked agent (inline) | bash wrapper + headless session | ⚠️ 机制不同，目标相同 |
+| Auto-dream Consolidation | forked agent + lock + gates | bash wrapper + lock + gates (24h/5 sessions) | ⚠️ 机制不同，目标相同 |
+| Age Warning | 基于 mtime | 同样的逻辑 | ✅ 完全覆盖 |
+| Ignore Memory 指令 | 支持 | regex 检测 + 环境变量 | ✅ 覆盖 |
+| **Recall 机制** | **LLM sideQuery (Sonnet)** | **关键词评分** | ❌ 质量差距大 |
+| **Searching Past Context** | grep memory + transcript 兜底 | **未实现** | ❌ 缺失 |
+| **alreadySurfaced 跨 turn 去重** | 支持，跨 turn 追踪 | 参数存在但未实际跨 turn 追踪 | ❌ 缺失 |
+| **recentTools 过滤** | 避免重复推送工具文档 | **未实现** | ❌ 缺失 |
+| Session Memory | 会话级压缩摘要 | 未实现 | ❌ 缺失 (平台限制) |
+| Team Memory | team/ 子目录 + sync + combined prompt | 未实现 | ❌ 缺失 (企业特性) |
+| KAIROS Daily-log 模式 | append-only log + nightly distillation | 未实现 | ❌ 缺失 (实验特性) |
+| Memory 晋升 (/remember) | CLAUDE.md / CLAUDE.local.md 迁移 | 未实现 | ❌ 缺失 (低优先级) |
+| Analytics / Telemetry | GrowthBook + logEvent | 未实现 | ❌ 缺失 (可接受) |
+| Feature Gates | GrowthBook 灰度 | 环境变量替代 | ⚠️ 简化替代 |
+| Cowork Memory Policies | 环境变量注入 extra guidelines | 未实现 | ❌ 缺失 (可接受) |
+| /memory 命令 + 编辑器 UI | React/Ink 文件选择器 + $EDITOR | 未实现 | ❌ 缺失 (平台限制) |
+
+## 关键差距详解
+
+### 1. 🔴 Recall 质量 (影响：高)
+
+Claude Code 用 Sonnet sideQuery 做语义选择，opencode-memory 用关键词频率计数。这是架构限制——OpenCode 插件环境无 sideQuery 等价能力。
+
+**可行缓解**：增强关键词策略——description 字段加权、多词短语匹配、TF-IDF 风格评分。
+
+### 2. 🟡 Searching Past Context (影响：中，易修复)
+
+Claude Code 在 prompt 中教模型搜索 memory 目录和 transcript。opencode-memory 完全缺失这个 section。
+
+**修复成本**：纯 prompt 文本添加，~15 行代码。
+
+### 3. 🟡 alreadySurfaced 跨 turn 追踪 (影响：中)
+
+`recallRelevantMemories()` 接受 `alreadySurfaced` 参数，但 `index.ts` 未维护跨 turn 的 Set。每次 turn 都可能重复推送相同 memory。
+
+**修复成本**：在 index.ts 中维护 per-session Set，~15 行代码。
+
+### 4. 🟡 recentTools 过滤 (影响：中低)
+
+Claude Code 在 recall 时传入 recentTools，避免推送当前已使用工具的参考文档。
+
+**修复成本**：利用 `tool.execute.after` hook 追踪，传给 recall，~25 行代码。
+
+### 5. 🔵 Session Memory / Team Memory / KAIROS (影响：低或平台限制)
+
+这些是高级子系统，或需平台支持，或面向企业场景，暂不实现。
+
+## 修复计划
+
+按优先级排序：
+
+1. **Searching Past Context section** → `prompt.ts` 添加
+2. **Enhanced keyword scoring** → `recall.ts` description 加权 + 改进评分
+3. **alreadySurfaced 跨 turn 追踪** → `index.ts` per-session Set
+4. **recentTools 过滤** → `index.ts` tool.execute.after hook + `recall.ts` 参数

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,31 +12,132 @@ import {
 } from "./memory.js"
 import { getMemoryDir } from "./paths.js"
 
+const latestUserQueryBySession = new Map<string, string>()
+
+function shouldIgnoreMemoryContext(query: string | undefined): boolean {
+  if (process.env.OPENCODE_MEMORY_IGNORE === "1") return true
+  if (!query) return false
+
+  const normalized = query.toLowerCase()
+  return (
+    /(ignore|don't use|do not use|without|skip)\s+(the\s+)?memory/.test(normalized) ||
+    /memory\s+(should be|must be)?\s*ignored/.test(normalized)
+  )
+}
+
+function extractUserQuery(message: unknown): string | undefined {
+  if (!message || typeof message !== "object") return undefined
+
+  if ("content" in message) {
+    const content = (message as { content?: unknown }).content
+    if (typeof content === "string") return content
+    if (content !== undefined) return JSON.stringify(content)
+  }
+
+  if ("parts" in message) {
+    const parts = (message as { parts?: unknown }).parts
+    if (Array.isArray(parts)) {
+      const text = parts
+        .map((part) => {
+          if (!part || typeof part !== "object") return ""
+          return typeof (part as { text?: unknown }).text === "string"
+            ? (part as { text: string }).text
+            : ""
+        })
+        .filter(Boolean)
+        .join("\n")
+        .trim()
+      if (text) return text
+    }
+  }
+
+  return undefined
+}
+
+function getLastUserQuery(messages: Array<{ info?: { role?: unknown; sessionID?: unknown }; parts?: unknown }>): {
+  query?: string
+  sessionID?: string
+} {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i]
+    if (message?.info?.role !== "user") continue
+
+    const query = extractUserQuery(message)
+    const sessionID = typeof message.info?.sessionID === "string" ? message.info.sessionID : undefined
+    return { query, sessionID }
+  }
+
+  return {}
+}
+
+function cacheLatestUserQuery(sessionID: string | undefined, message: unknown): void {
+  if (!sessionID) return
+  const query = extractUserQuery(message)
+  if (query) {
+    latestUserQueryBySession.set(sessionID, query)
+  }
+}
+
+function isAutoMemoryPart(part: unknown): boolean {
+  if (!part || typeof part !== "object") return false
+  return typeof (part as { text?: unknown }).text === "string" &&
+    (part as { text: string }).text.includes("# Auto Memory")
+}
+
 export const MemoryPlugin: Plugin = async ({ worktree }) => {
   getMemoryDir(worktree)
 
   return {
+    "chat.message": async (input, output) => {
+      cacheLatestUserQuery(input.sessionID, { parts: output.parts })
+    },
+
+    "experimental.chat.messages.transform": async (_input, output) => {
+      const { query, sessionID } = getLastUserQuery(output.messages)
+      if (query && sessionID) latestUserQueryBySession.set(sessionID, query)
+
+      if (shouldIgnoreMemoryContext(query)) {
+        output.messages = output.messages
+          .map((message) => {
+            const role = String(message.info.role)
+            if (role !== "system") return message
+
+            const parts = message.parts.filter((part) => !isAutoMemoryPart(part))
+            return { ...message, parts }
+          })
+          .filter((message) => message.parts.length > 0)
+      }
+    },
+
     "experimental.chat.system.transform": async (_input, output) => {
       let query: string | undefined
+      let sessionID: string | undefined
       if (_input && typeof _input === "object") {
+        sessionID = (typeof (_input as { sessionID?: unknown }).sessionID === "string"
+          ? (_input as { sessionID?: string }).sessionID
+          : undefined)
+        if (sessionID) {
+          query = latestUserQueryBySession.get(sessionID)
+        }
+
         const messages = (_input as { messages?: unknown }).messages
-        if (Array.isArray(messages)) {
+        if (!query && Array.isArray(messages)) {
           const lastUserMsg = [...messages]
             .reverse()
             .find((message) =>
               message && typeof message === "object" && "role" in message && (message as { role?: unknown }).role === "user",
             )
 
-          if (lastUserMsg && typeof lastUserMsg === "object" && "content" in lastUserMsg) {
-            const content = (lastUserMsg as { content?: unknown }).content
-            query = typeof content === "string" ? content : JSON.stringify(content)
-          }
+          query = extractUserQuery(lastUserMsg)
         }
       }
 
-      const recalled = recallRelevantMemories(worktree, query)
+      const ignoreMemoryContext = process.env.OPENCODE_MEMORY_IGNORE === "1" || shouldIgnoreMemoryContext(query)
+      const recalled = ignoreMemoryContext ? [] : recallRelevantMemories(worktree, query)
       const recalledSection = formatRecalledMemories(recalled)
-      const memoryPrompt = buildMemorySystemPrompt(worktree, recalledSection)
+      const memoryPrompt = buildMemorySystemPrompt(worktree, recalledSection, {
+        includeIndex: !ignoreMemoryContext,
+      })
       output.system.push(memoryPrompt)
     },
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,10 @@ import {
 import { getMemoryDir } from "./paths.js"
 
 const latestUserQueryBySession = new Map<string, string>()
+const surfacedMemoriesBySession = new Map<string, Set<string>>()
+const recentToolsBySession = new Map<string, string[]>()
+
+const MAX_RECENT_TOOLS = 20
 
 function shouldIgnoreMemoryContext(query: string | undefined): boolean {
   if (process.env.OPENCODE_MEMORY_IGNORE === "1") return true
@@ -92,6 +96,21 @@ export const MemoryPlugin: Plugin = async ({ worktree }) => {
       cacheLatestUserQuery(input.sessionID, { parts: output.parts })
     },
 
+    "tool.execute.after": async (input) => {
+      const { tool: toolName, sessionID } = input
+      if (!sessionID || !toolName) return
+      if (!recentToolsBySession.has(sessionID)) {
+        recentToolsBySession.set(sessionID, [])
+      }
+      const tools = recentToolsBySession.get(sessionID)!
+      if (!tools.includes(toolName)) {
+        tools.push(toolName)
+        if (tools.length > MAX_RECENT_TOOLS) {
+          tools.shift()
+        }
+      }
+    },
+
     "experimental.chat.messages.transform": async (_input, output) => {
       const { query, sessionID } = getLastUserQuery(output.messages)
       if (query && sessionID) latestUserQueryBySession.set(sessionID, query)
@@ -133,7 +152,20 @@ export const MemoryPlugin: Plugin = async ({ worktree }) => {
       }
 
       const ignoreMemoryContext = process.env.OPENCODE_MEMORY_IGNORE === "1" || shouldIgnoreMemoryContext(query)
-      const recalled = ignoreMemoryContext ? [] : recallRelevantMemories(worktree, query)
+      const alreadySurfaced = sessionID ? (surfacedMemoriesBySession.get(sessionID) ?? new Set()) : new Set<string>()
+      const recentTools = sessionID ? (recentToolsBySession.get(sessionID) ?? []) : []
+      const recalled = ignoreMemoryContext ? [] : recallRelevantMemories(worktree, query, alreadySurfaced, recentTools)
+
+      if (sessionID && recalled.length > 0) {
+        if (!surfacedMemoriesBySession.has(sessionID)) {
+          surfacedMemoriesBySession.set(sessionID, new Set())
+        }
+        const surfaced = surfacedMemoriesBySession.get(sessionID)!
+        for (const mem of recalled) {
+          surfaced.add(mem.filePath)
+        }
+      }
+
       const recalledSection = formatRecalledMemories(recalled)
       const memoryPrompt = buildMemorySystemPrompt(worktree, recalledSection, {
         includeIndex: !ignoreMemoryContext,

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,11 +12,17 @@ import {
 } from "./memory.js"
 import { getMemoryDir } from "./paths.js"
 
-const latestUserQueryBySession = new Map<string, string>()
-const surfacedMemoriesBySession = new Map<string, Set<string>>()
-const recentToolsBySession = new Map<string, string[]>()
+// Per-turn derived state — overwritten each time messages.transform fires.
+// This replaces the old process-global session Maps so that compact naturally
+// resets both alreadySurfaced and recentTools (the messages shrink after compact,
+// so the derived state shrinks with them).
+type TurnContext = {
+  query?: string
+  alreadySurfaced: Set<string>
+  recentTools: string[]
+}
 
-const MAX_RECENT_TOOLS = 20
+const turnContextBySession = new Map<string, TurnContext>()
 
 function shouldIgnoreMemoryContext(query: string | undefined): boolean {
   if (process.env.OPENCODE_MEMORY_IGNORE === "1") return true
@@ -74,46 +80,78 @@ function getLastUserQuery(messages: Array<{ info?: { role?: unknown; sessionID?:
   return {}
 }
 
-function cacheLatestUserQuery(sessionID: string | undefined, message: unknown): void {
-  if (!sessionID) return
-  const query = extractUserQuery(message)
-  if (query) {
-    latestUserQueryBySession.set(sessionID, query)
-  }
-}
-
 function isAutoMemoryPart(part: unknown): boolean {
   if (!part || typeof part !== "object") return false
   return typeof (part as { text?: unknown }).text === "string" &&
     (part as { text: string }).text.includes("# Auto Memory")
 }
 
+// Parses "### <name> (<type>)" headers from the ## Recalled Memories section
+// of system prompts. After compaction old system messages disappear, so
+// the returned set naturally shrinks — no manual reset needed.
+function extractSurfacedMemoryKeys(systemText: string): Set<string> {
+  const keys = new Set<string>()
+  const recalledSection = systemText.indexOf("## Recalled Memories")
+  if (recalledSection === -1) return keys
+
+  const headerPattern = /^### (.+?) \((\w+)\)/gm
+  const section = systemText.slice(recalledSection)
+  for (let match = headerPattern.exec(section); match !== null; match = headerPattern.exec(section)) {
+    keys.add(`${match[1]}|${match[2]}`)
+  }
+  return keys
+}
+
+// Only completed tools — matches Claude Code's collectRecentSuccessfulTools().
+function extractRecentTools(
+  messages: Array<{ info?: { role?: unknown }; parts?: unknown[] }>,
+): string[] {
+  const tools: string[] = []
+  const seen = new Set<string>()
+  for (const message of messages) {
+    if (!message.parts || !Array.isArray(message.parts)) continue
+    for (const part of message.parts) {
+      if (!part || typeof part !== "object") continue
+      const p = part as { type?: string; tool?: string; state?: { status?: string } }
+      if (p.type !== "tool" || !p.tool) continue
+      if (p.state?.status !== "completed") continue
+      if (seen.has(p.tool)) continue
+      seen.add(p.tool)
+      tools.push(p.tool)
+    }
+  }
+  return tools
+}
+
 export const MemoryPlugin: Plugin = async ({ worktree }) => {
   getMemoryDir(worktree)
 
   return {
-    "chat.message": async (input, output) => {
-      cacheLatestUserQuery(input.sessionID, { parts: output.parts })
-    },
-
-    "tool.execute.after": async (input) => {
-      const { tool: toolName, sessionID } = input
-      if (!sessionID || !toolName) return
-      if (!recentToolsBySession.has(sessionID)) {
-        recentToolsBySession.set(sessionID, [])
-      }
-      const tools = recentToolsBySession.get(sessionID)!
-      if (!tools.includes(toolName)) {
-        tools.push(toolName)
-        if (tools.length > MAX_RECENT_TOOLS) {
-          tools.shift()
-        }
-      }
-    },
-
     "experimental.chat.messages.transform": async (_input, output) => {
       const { query, sessionID } = getLastUserQuery(output.messages)
-      if (query && sessionID) latestUserQueryBySession.set(sessionID, query)
+
+      if (sessionID) {
+        const alreadySurfaced = new Set<string>()
+        for (const message of output.messages) {
+          const role = String(message.info.role)
+          if (role !== "system") continue
+          for (const part of message.parts) {
+            if (!part || typeof part !== "object") continue
+            const text = (part as { text?: string }).text
+            if (typeof text === "string") {
+              for (const key of extractSurfacedMemoryKeys(text)) {
+                alreadySurfaced.add(key)
+              }
+            }
+          }
+        }
+
+        const recentTools = extractRecentTools(
+          output.messages as Array<{ info?: { role?: unknown }; parts?: unknown[] }>,
+        )
+
+        turnContextBySession.set(sessionID, { query, alreadySurfaced, recentTools })
+      }
 
       if (shouldIgnoreMemoryContext(query)) {
         output.messages = output.messages
@@ -129,42 +167,20 @@ export const MemoryPlugin: Plugin = async ({ worktree }) => {
     },
 
     "experimental.chat.system.transform": async (_input, output) => {
-      let query: string | undefined
       let sessionID: string | undefined
       if (_input && typeof _input === "object") {
         sessionID = (typeof (_input as { sessionID?: unknown }).sessionID === "string"
           ? (_input as { sessionID?: string }).sessionID
           : undefined)
-        if (sessionID) {
-          query = latestUserQueryBySession.get(sessionID)
-        }
-
-        const messages = (_input as { messages?: unknown }).messages
-        if (!query && Array.isArray(messages)) {
-          const lastUserMsg = [...messages]
-            .reverse()
-            .find((message) =>
-              message && typeof message === "object" && "role" in message && (message as { role?: unknown }).role === "user",
-            )
-
-          query = extractUserQuery(lastUserMsg)
-        }
       }
+
+      const ctx = sessionID ? turnContextBySession.get(sessionID) : undefined
+      const query = ctx?.query
+      const alreadySurfaced = ctx?.alreadySurfaced ?? new Set<string>()
+      const recentTools = ctx?.recentTools ?? []
 
       const ignoreMemoryContext = process.env.OPENCODE_MEMORY_IGNORE === "1" || shouldIgnoreMemoryContext(query)
-      const alreadySurfaced = sessionID ? (surfacedMemoriesBySession.get(sessionID) ?? new Set()) : new Set<string>()
-      const recentTools = sessionID ? (recentToolsBySession.get(sessionID) ?? []) : []
       const recalled = ignoreMemoryContext ? [] : recallRelevantMemories(worktree, query, alreadySurfaced, recentTools)
-
-      if (sessionID && recalled.length > 0) {
-        if (!surfacedMemoriesBySession.has(sessionID)) {
-          surfacedMemoriesBySession.set(sessionID, new Set())
-        }
-        const surfaced = surfacedMemoriesBySession.get(sessionID)!
-        for (const mem of recalled) {
-          surfaced.add(mem.filePath)
-        }
-      }
 
       const recalledSection = formatRecalledMemories(recalled)
       const memoryPrompt = buildMemorySystemPrompt(worktree, recalledSection, {

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync, readdirSync, unlinkSync, existsSync } from "fs"
+import { readFileSync, writeFileSync, readdirSync, unlinkSync } from "fs"
 import { join, basename } from "path"
 import {
   getMemoryDir,
@@ -7,6 +7,8 @@ import {
   validateMemoryFileName,
   MAX_MEMORY_FILES,
   MAX_MEMORY_FILE_BYTES,
+  MAX_ENTRYPOINT_LINES,
+  MAX_ENTRYPOINT_BYTES,
   FRONTMATTER_MAX_LINES,
 } from "./paths.js"
 
@@ -75,22 +77,23 @@ export function listMemories(worktree: string): MemoryEntry[] {
 
   let files: string[]
   try {
-    files = readdirSync(memDir)
-      .filter((f) => f.endsWith(".md") && f !== ENTRYPOINT_NAME)
+    files = (readdirSync(memDir, { recursive: true, encoding: "utf-8" }) as string[])
+      .filter((f: string) => f.endsWith(".md") && basename(f) !== ENTRYPOINT_NAME)
       .sort()
       .slice(0, MAX_MEMORY_FILES)
   } catch {
     return entries
   }
 
-  for (const fileName of files) {
-    const filePath = join(memDir, fileName)
+  for (const relativePath of files) {
+    const filePath = join(memDir, relativePath)
+    const fileName = basename(relativePath)
     try {
       const rawContent = readFileSync(filePath, "utf-8")
       const { frontmatter, content } = parseFrontmatter(rawContent)
       entries.push({
         filePath,
-        fileName,
+        fileName: relativePath,
         name: frontmatter.name ?? fileName.replace(/\.md$/, ""),
         description: frontmatter.description ?? "",
         type: parseMemoryType(frontmatter.type) ?? "user",
@@ -214,30 +217,57 @@ function removeFromIndex(worktree: string, fileName: string): void {
   writeFileSync(entrypoint, lines.length > 0 ? lines.join("\n") + "\n" : "", "utf-8")
 }
 
-export function truncateEntrypoint(raw: string): { content: string; wasTruncated: boolean } {
-  const trimmed = raw.trim()
-  if (!trimmed) return { content: "", wasTruncated: false }
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`
+  return `${(bytes / 1024).toFixed(1)}KB`
+}
 
-  const lines = trimmed.split("\n")
-  const lineCount = lines.length
+export type EntrypointTruncation = {
+  content: string
+  lineCount: number
+  byteCount: number
+  wasLineTruncated: boolean
+  wasByteTruncated: boolean
+}
+
+// Port of Claude Code's truncateEntrypointContent() from memdir.ts.
+// Uses .length (char count, same as Claude Code) for byte measurement.
+export function truncateEntrypoint(raw: string): EntrypointTruncation {
+  const trimmed = raw.trim()
+  if (!trimmed) return { content: "", lineCount: 0, byteCount: 0, wasLineTruncated: false, wasByteTruncated: false }
+
+  const contentLines = trimmed.split("\n")
+  const lineCount = contentLines.length
   const byteCount = trimmed.length
 
-  const wasLineTruncated = lineCount > 200
-  const wasByteTruncated = byteCount > 25_000
+  const wasLineTruncated = lineCount > MAX_ENTRYPOINT_LINES
+  const wasByteTruncated = byteCount > MAX_ENTRYPOINT_BYTES
 
   if (!wasLineTruncated && !wasByteTruncated) {
-    return { content: trimmed, wasTruncated: false }
+    return { content: trimmed, lineCount, byteCount, wasLineTruncated, wasByteTruncated }
   }
 
-  let truncated = wasLineTruncated ? lines.slice(0, 200).join("\n") : trimmed
+  let truncated = wasLineTruncated
+    ? contentLines.slice(0, MAX_ENTRYPOINT_LINES).join("\n")
+    : trimmed
 
-  if (truncated.length > 25_000) {
-    const cutAt = truncated.lastIndexOf("\n", 25_000)
-    truncated = truncated.slice(0, cutAt > 0 ? cutAt : 25_000)
+  if (truncated.length > MAX_ENTRYPOINT_BYTES) {
+    const cutAt = truncated.lastIndexOf("\n", MAX_ENTRYPOINT_BYTES)
+    truncated = truncated.slice(0, cutAt > 0 ? cutAt : MAX_ENTRYPOINT_BYTES)
   }
+
+  const reason =
+    wasByteTruncated && !wasLineTruncated
+      ? `${formatFileSize(byteCount)} (limit: ${formatFileSize(MAX_ENTRYPOINT_BYTES)}) — index entries are too long`
+      : wasLineTruncated && !wasByteTruncated
+        ? `${lineCount} lines (limit: ${MAX_ENTRYPOINT_LINES})`
+        : `${lineCount} lines and ${formatFileSize(byteCount)}`
 
   return {
-    content: truncated + "\n\n> WARNING: MEMORY.md was truncated. Keep index entries concise.",
-    wasTruncated: true,
+    content: truncated + `\n\n> WARNING: ${ENTRYPOINT_NAME} is ${reason}. Only part of it was loaded. Keep index entries to one line under ~200 chars; move detail into topic files.`,
+    lineCount,
+    byteCount,
+    wasLineTruncated,
+    wasByteTruncated,
   }
 }

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -77,23 +77,22 @@ export function listMemories(worktree: string): MemoryEntry[] {
 
   let files: string[]
   try {
-    files = (readdirSync(memDir, { recursive: true, encoding: "utf-8" }) as string[])
-      .filter((f: string) => f.endsWith(".md") && basename(f) !== ENTRYPOINT_NAME)
+    files = readdirSync(memDir, { encoding: "utf-8" })
+      .filter((f) => f.endsWith(".md") && f !== ENTRYPOINT_NAME)
       .sort()
       .slice(0, MAX_MEMORY_FILES)
   } catch {
     return entries
   }
 
-  for (const relativePath of files) {
-    const filePath = join(memDir, relativePath)
-    const fileName = basename(relativePath)
+  for (const fileName of files) {
+    const filePath = join(memDir, fileName)
     try {
       const rawContent = readFileSync(filePath, "utf-8")
       const { frontmatter, content } = parseFrontmatter(rawContent)
       entries.push({
         filePath,
-        fileName: relativePath,
+        fileName,
         name: frontmatter.name ?? fileName.replace(/\.md$/, ""),
         description: frontmatter.description ?? "",
         type: parseMemoryType(frontmatter.type) ?? "user",

--- a/src/memoryScan.ts
+++ b/src/memoryScan.ts
@@ -12,6 +12,7 @@ export type MemoryHeader = {
   filename: string
   filePath: string
   mtimeMs: number
+  name: string | null
   description: string | null
   type: MemoryType | undefined
 }
@@ -90,6 +91,7 @@ export function scanMemoryFiles(memoryDir: string): MemoryHeader[] {
           filename: relativePath,
           filePath,
           mtimeMs,
+          name: frontmatter.name || null,
           description: frontmatter.description || null,
           type: parseMemoryType(frontmatter.type),
         })

--- a/src/memoryScan.ts
+++ b/src/memoryScan.ts
@@ -1,0 +1,128 @@
+import { readdirSync, readFileSync, statSync } from "fs"
+import { basename, join } from "path"
+import {
+  getMemoryDir,
+  ENTRYPOINT_NAME,
+  MAX_MEMORY_FILES,
+  FRONTMATTER_MAX_LINES,
+} from "./paths.js"
+import type { MemoryType } from "./memory.js"
+
+export type MemoryHeader = {
+  filename: string
+  filePath: string
+  mtimeMs: number
+  description: string | null
+  type: MemoryType | undefined
+}
+
+const MEMORY_TYPES: readonly string[] = ["user", "feedback", "project", "reference"]
+
+function parseMemoryType(raw: string | undefined): MemoryType | undefined {
+  if (!raw) return undefined
+  return MEMORY_TYPES.includes(raw) ? (raw as MemoryType) : undefined
+}
+
+function readFileHeader(filePath: string, maxLines: number): { content: string; mtimeMs: number } {
+  try {
+    const raw = readFileSync(filePath, "utf-8")
+    const stat = statSync(filePath)
+    const lines = raw.split("\n")
+    const header = lines.slice(0, maxLines).join("\n")
+    return { content: header, mtimeMs: stat.mtimeMs }
+  } catch {
+    return { content: "", mtimeMs: 0 }
+  }
+}
+
+function parseFrontmatterHeader(raw: string): Record<string, string> {
+  const trimmed = raw.trim()
+  if (!trimmed.startsWith("---")) {
+    return {}
+  }
+
+  const lines = trimmed.split("\n")
+  let closingLineIdx = -1
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i].trimEnd() === "---") {
+      closingLineIdx = i
+      break
+    }
+  }
+  if (closingLineIdx === -1) {
+    return {}
+  }
+
+  const frontmatter: Record<string, string> = {}
+  for (let i = 1; i < closingLineIdx; i++) {
+    const line = lines[i]
+    const colonIdx = line.indexOf(":")
+    if (colonIdx === -1) continue
+    const key = line.slice(0, colonIdx).trim()
+    const value = line.slice(colonIdx + 1).trim()
+    if (key && value) {
+      frontmatter[key] = value
+    }
+  }
+
+  return frontmatter
+}
+
+/**
+ * Recursive scan of memory directory. Reads only frontmatter (first N lines),
+ * returns headers sorted by mtime desc, capped at MAX_MEMORY_FILES.
+ * Port of Claude Code's scanMemoryFiles().
+ */
+export function scanMemoryFiles(memoryDir: string): MemoryHeader[] {
+  try {
+    const entries = readdirSync(memoryDir, { recursive: true, encoding: "utf-8" }) as string[]
+    const mdFiles = entries.filter(
+      (f: string) => f.endsWith(".md") && basename(f) !== ENTRYPOINT_NAME,
+    )
+
+    const headers: MemoryHeader[] = []
+    for (const relativePath of mdFiles) {
+      const filePath = join(memoryDir, relativePath)
+      try {
+        const { content, mtimeMs } = readFileHeader(filePath, FRONTMATTER_MAX_LINES)
+        const frontmatter = parseFrontmatterHeader(content)
+        headers.push({
+          filename: relativePath,
+          filePath,
+          mtimeMs,
+          description: frontmatter.description || null,
+          type: parseMemoryType(frontmatter.type),
+        })
+      } catch {
+        // skip unreadable files
+      }
+    }
+
+    return headers
+      .sort((a, b) => b.mtimeMs - a.mtimeMs)
+      .slice(0, MAX_MEMORY_FILES)
+  } catch {
+    return []
+  }
+}
+
+// Port of Claude Code's formatMemoryManifest():
+// `- [type] filename (ISO timestamp): description` per line
+export function formatMemoryManifest(memories: MemoryHeader[]): string {
+  return memories
+    .map((m) => {
+      const tag = m.type ? `[${m.type}] ` : ""
+      const ts = new Date(m.mtimeMs).toISOString()
+      return m.description
+        ? `- ${tag}${m.filename} (${ts}): ${m.description}`
+        : `- ${tag}${m.filename} (${ts})`
+    })
+    .join("\n")
+}
+
+export function getMemoryManifest(worktree: string): { headers: MemoryHeader[]; manifest: string } {
+  const memoryDir = getMemoryDir(worktree)
+  const headers = scanMemoryFiles(memoryDir)
+  const manifest = formatMemoryManifest(headers)
+  return { headers, manifest }
+}

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -141,10 +141,13 @@ function getClaudeConfigHomeDir(): string {
   return (process.env.CLAUDE_CONFIG_DIR ?? join(homedir(), ".claude")).normalize("NFC")
 }
 
-export function getMemoryDir(worktree: string): string {
+export function getProjectDir(worktree: string): string {
   const canonicalRoot = findCanonicalGitRoot(worktree) ?? worktree
-  const projectsDir = join(getClaudeConfigHomeDir(), "projects")
-  const memoryDir = join(projectsDir, sanitizePath(canonicalRoot), "memory")
+  return join(getClaudeConfigHomeDir(), "projects", sanitizePath(canonicalRoot))
+}
+
+export function getMemoryDir(worktree: string): string {
+  const memoryDir = join(getProjectDir(worktree), "memory")
   ensureDir(memoryDir)
   return memoryDir
 }

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -120,9 +120,18 @@ const TRUSTING_RECALL = [
   "A memory that summarizes repo state (activity logs, architecture snapshots) is frozen in time. If the user asks about *recent* or *current* state, prefer `git log` or reading the code over recalling the snapshot.",
 ].join("\n")
 
-export function buildMemorySystemPrompt(worktree: string, recalledMemoriesSection?: string): string {
+export type BuildMemorySystemPromptOptions = {
+  includeIndex?: boolean
+}
+
+export function buildMemorySystemPrompt(
+  worktree: string,
+  recalledMemoriesSection?: string,
+  options: BuildMemorySystemPromptOptions = {},
+): string {
   const memoryDir = getMemoryDir(worktree)
   const indexContent = readIndex(worktree)
+  const includeIndex = options.includeIndex ?? true
 
   const howToSave = [
     "## How to save memories",
@@ -167,15 +176,17 @@ export function buildMemorySystemPrompt(worktree: string, recalledMemoriesSectio
     "",
   ]
 
-  if (indexContent.trim()) {
-    const { content: truncated } = truncateEntrypoint(indexContent)
-    lines.push(`## ${ENTRYPOINT_NAME}`, "", truncated)
-  } else {
-    lines.push(
-      `## ${ENTRYPOINT_NAME}`,
-      "",
-      `Your ${ENTRYPOINT_NAME} is currently empty. When you save new memories, they will appear here.`,
-    )
+  if (includeIndex) {
+    if (indexContent.trim()) {
+      const { content: truncated } = truncateEntrypoint(indexContent)
+      lines.push(`## ${ENTRYPOINT_NAME}`, "", truncated)
+    } else {
+      lines.push(
+        `## ${ENTRYPOINT_NAME}`,
+        "",
+        `Your ${ENTRYPOINT_NAME} is currently empty. When you save new memories, they will appear here.`,
+      )
+    }
   }
 
   if (recalledMemoriesSection?.trim()) {

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -1,6 +1,6 @@
 import { MEMORY_TYPES } from "./memory.js"
 import { readIndex, truncateEntrypoint } from "./memory.js"
-import { getMemoryDir, ENTRYPOINT_NAME, MAX_ENTRYPOINT_LINES } from "./paths.js"
+import { getMemoryDir, ENTRYPOINT_NAME, MAX_ENTRYPOINT_LINES, getProjectDir } from "./paths.js"
 
 // Port of Claude Code's MEMORY_FRONTMATTER_EXAMPLE from memoryTypes.ts
 const FRONTMATTER_EXAMPLE = [
@@ -120,6 +120,29 @@ const TRUSTING_RECALL = [
   "A memory that summarizes repo state (activity logs, architecture snapshots) is frozen in time. If the user asks about *recent* or *current* state, prefer `git log` or reading the code over recalling the snapshot.",
 ].join("\n")
 
+// Port of Claude Code's buildSearchingPastContextSection() from memdir.ts.
+// Guides the model to grep memory files and session transcripts when
+// looking for past context, rather than guessing or hallucinating.
+function buildSearchingPastContextSection(memoryDir: string, projectDir: string): string[] {
+  const memSearch = `grep -rn "<search term>" ${memoryDir} --include="*.md"`
+  const transcriptSearch = `grep -rn "<search term>" ${projectDir}/ --include="*.jsonl"`
+  return [
+    "## Searching past context",
+    "",
+    "When looking for past context:",
+    "1. Search topic files in your memory directory:",
+    "```",
+    memSearch,
+    "```",
+    "2. Session transcript logs (last resort — large files, slow):",
+    "```",
+    transcriptSearch,
+    "```",
+    "Use narrow search terms (error messages, file paths, function names) rather than broad keywords.",
+    "",
+  ]
+}
+
 export type BuildMemorySystemPromptOptions = {
   includeIndex?: boolean
 }
@@ -130,6 +153,7 @@ export function buildMemorySystemPrompt(
   options: BuildMemorySystemPromptOptions = {},
 ): string {
   const memoryDir = getMemoryDir(worktree)
+  const projectDir = getProjectDir(worktree)
   const indexContent = readIndex(worktree)
   const includeIndex = options.includeIndex ?? true
 
@@ -174,6 +198,7 @@ export function buildMemorySystemPrompt(
     "- When to use or update a plan instead of memory: If you are about to start a non-trivial implementation task and would like to reach alignment with the user on your approach you should use a Plan rather than saving this information to memory. Similarly, if you already have a plan within the conversation and you have changed your approach persist that change by updating the plan rather than saving a memory.",
     "- When to use or update tasks instead of memory: When you need to break your work in current conversation into discrete steps or keep track of your progress use tasks instead of saving to memory. Tasks are great for persisting information about the work that needs to be done in the current conversation, but memory should be reserved for information that will be useful in future conversations.",
     "",
+    ...buildSearchingPastContextSection(memoryDir, projectDir),
   ]
 
   if (includeIndex) {

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -1,97 +1,146 @@
 import { MEMORY_TYPES } from "./memory.js"
 import { readIndex, truncateEntrypoint } from "./memory.js"
-import { getMemoryDir, ENTRYPOINT_NAME } from "./paths.js"
+import { getMemoryDir, ENTRYPOINT_NAME, MAX_ENTRYPOINT_LINES } from "./paths.js"
 
-const FRONTMATTER_EXAMPLE = `\`\`\`markdown
----
-name: {{memory name}}
-description: {{one-line description — used to decide relevance in future conversations, so be specific}}
-type: {{${MEMORY_TYPES.join(", ")}}}
----
+// Port of Claude Code's MEMORY_FRONTMATTER_EXAMPLE from memoryTypes.ts
+const FRONTMATTER_EXAMPLE = [
+  "```markdown",
+  "---",
+  "name: {{memory name}}",
+  "description: {{one-line description — used to decide relevance in future conversations, so be specific}}",
+  `type: {{${MEMORY_TYPES.join(", ")}}}`,
+  "---",
+  "",
+  "{{memory content — for feedback/project types, structure as: rule/fact, then **Why:** and **How to apply:** lines}}",
+  "```",
+]
 
-{{memory content — for feedback/project types, structure as: rule/fact, then **Why:** and **How to apply:** lines}}
-\`\`\``
+// Port of Claude Code's TYPES_SECTION_INDIVIDUAL from memoryTypes.ts
+const TYPES_SECTION = [
+  "## Types of memory",
+  "",
+  "There are several discrete types of memory that you can store in your memory system:",
+  "",
+  "<types>",
+  "<type>",
+  "    <name>user</name>",
+  "    <description>Contain information about the user's role, goals, responsibilities, and knowledge. Great user memories help you tailor your future behavior to the user's preferences and perspective. Your goal in reading and writing these memories is to build up an understanding of who the user is and how you can be most helpful to them specifically. For example, you should collaborate with a senior software engineer differently than a student who is coding for the very first time. Keep in mind, that the aim here is to be helpful to the user. Avoid writing memories about the user that could be viewed as a negative judgement or that are not relevant to the work you're trying to accomplish together.</description>",
+  "    <when_to_save>When you learn any details about the user's role, preferences, responsibilities, or knowledge</when_to_save>",
+  "    <how_to_use>When your work should be informed by the user's profile or perspective. For example, if the user is asking you to explain a part of the code, you should answer that question in a way that is tailored to the specific details that they will find most valuable or that helps them build their mental model in relation to domain knowledge they already have.</how_to_use>",
+  "    <examples>",
+  "    user: I'm a data scientist investigating what logging we have in place",
+  "    assistant: [saves user memory: user is a data scientist, currently focused on observability/logging]",
+  "",
+  "    user: I've been writing Go for ten years but this is my first time touching the React side of this repo",
+  "    assistant: [saves user memory: deep Go expertise, new to React and this project's frontend — frame frontend explanations in terms of backend analogues]",
+  "    </examples>",
+  "</type>",
+  "<type>",
+  "    <name>feedback</name>",
+  "    <description>Guidance the user has given you about how to approach work — both what to avoid and what to keep doing. These are a very important type of memory to read and write as they allow you to remain coherent and responsive to the way you should approach work in the project. Record from failure AND success: if you only save corrections, you will avoid past mistakes but drift away from approaches the user has already validated, and may grow overly cautious.</description>",
+  "    <when_to_save>Any time the user corrects your approach (\"no not that\", \"don't\", \"stop doing X\") OR confirms a non-obvious approach worked (\"yes exactly\", \"perfect, keep doing that\", accepting an unusual choice without pushback). Corrections are easy to notice; confirmations are quieter — watch for them. In both cases, save what is applicable to future conversations, especially if surprising or not obvious from the code. Include *why* so you can judge edge cases later.</when_to_save>",
+  "    <how_to_use>Let these memories guide your behavior so that the user does not need to offer the same guidance twice.</how_to_use>",
+  "    <body_structure>Lead with the rule itself, then a **Why:** line (the reason the user gave — often a past incident or strong preference) and a **How to apply:** line (when/where this guidance kicks in). Knowing *why* lets you judge edge cases instead of blindly following the rule.</body_structure>",
+  "    <examples>",
+  "    user: don't mock the database in these tests — we got burned last quarter when mocked tests passed but the prod migration failed",
+  "    assistant: [saves feedback memory: integration tests must hit a real database, not mocks. Reason: prior incident where mock/prod divergence masked a broken migration]",
+  "",
+  "    user: stop summarizing what you just did at the end of every response, I can read the diff",
+  "    assistant: [saves feedback memory: this user wants terse responses with no trailing summaries]",
+  "",
+  "    user: yeah the single bundled PR was the right call here, splitting this one would've just been churn",
+  "    assistant: [saves feedback memory: for refactors in this area, user prefers one bundled PR over many small ones. Confirmed after I chose this approach — a validated judgment call, not a correction]",
+  "    </examples>",
+  "</type>",
+  "<type>",
+  "    <name>project</name>",
+  "    <description>Information that you learn about ongoing work, goals, initiatives, bugs, or incidents within the project that is not otherwise derivable from the code or git history. Project memories help you understand the broader context and motivation behind the work the user is doing within this working directory.</description>",
+  "    <when_to_save>When you learn who is doing what, why, or by when. These states change relatively quickly so try to keep your understanding of this up to date. Always convert relative dates in user messages to absolute dates when saving (e.g., \"Thursday\" → \"2026-03-05\"), so the memory remains interpretable after time passes.</when_to_save>",
+  "    <how_to_use>Use these memories to more fully understand the details and nuance behind the user's request and make better informed suggestions.</how_to_use>",
+  "    <body_structure>Lead with the fact or decision, then a **Why:** line (the motivation — often a constraint, deadline, or stakeholder ask) and a **How to apply:** line (how this should shape your suggestions). Project memories decay fast, so the why helps future-you judge whether the memory is still load-bearing.</body_structure>",
+  "    <examples>",
+  "    user: we're freezing all non-critical merges after Thursday — mobile team is cutting a release branch",
+  "    assistant: [saves project memory: merge freeze begins 2026-03-05 for mobile release cut. Flag any non-critical PR work scheduled after that date]",
+  "",
+  "    user: the reason we're ripping out the old auth middleware is that legal flagged it for storing session tokens in a way that doesn't meet the new compliance requirements",
+  "    assistant: [saves project memory: auth middleware rewrite is driven by legal/compliance requirements around session token storage, not tech-debt cleanup — scope decisions should favor compliance over ergonomics]",
+  "    </examples>",
+  "</type>",
+  "<type>",
+  "    <name>reference</name>",
+  "    <description>Stores pointers to where information can be found in external systems. These memories allow you to remember where to look to find up-to-date information outside of the project directory.</description>",
+  "    <when_to_save>When you learn about resources in external systems and their purpose. For example, that bugs are tracked in a specific project in Linear or that feedback can be found in a specific Slack channel.</when_to_save>",
+  "    <how_to_use>When the user references an external system or information that may be in an external system.</how_to_use>",
+  "    <examples>",
+  `    user: check the Linear project "INGEST" if you want context on these tickets, that's where we track all pipeline bugs`,
+  `    assistant: [saves reference memory: pipeline bugs are tracked in Linear project "INGEST"]`,
+  "",
+  "    user: the Grafana board at grafana.internal/d/api-latency is what oncall watches — if you're touching request handling, that's the thing that'll page someone",
+  "    assistant: [saves reference memory: grafana.internal/d/api-latency is the oncall latency dashboard — check it when editing request-path code]",
+  "    </examples>",
+  "</type>",
+  "</types>",
+  "",
+].join("\n")
 
-const TYPES_SECTION = `## Types of memory
+// Port of Claude Code's WHAT_NOT_TO_SAVE_SECTION from memoryTypes.ts
+const WHAT_NOT_TO_SAVE = [
+  "## What NOT to save in memory",
+  "",
+  "- Code patterns, conventions, architecture, file paths, or project structure — these can be derived by reading the current project state.",
+  "- Git history, recent changes, or who-changed-what — `git log` / `git blame` are authoritative.",
+  "- Debugging solutions or fix recipes — the fix is in the code; the commit message has the context.",
+  "- Anything already documented in AGENTS.md or project config files.",
+  "- Ephemeral task details: in-progress work, temporary state, current conversation context.",
+  "",
+  "These exclusions apply even when the user explicitly asks you to save. If they ask you to save a PR list or activity summary, ask what was *surprising* or *non-obvious* about it — that is the part worth keeping.",
+].join("\n")
 
-There are several discrete types of memory that you can store:
+// Port of Claude Code's WHEN_TO_ACCESS_SECTION from memoryTypes.ts
+const WHEN_TO_ACCESS = [
+  "## When to access memories",
+  "- When memories seem relevant, or the user references prior-conversation work.",
+  "- You MUST access memory when the user explicitly asks you to check, recall, or remember.",
+  "- If the user says to *ignore* or *not use* memory: proceed as if MEMORY.md were empty. Do not apply remembered facts, cite, compare against, or mention memory content.",
+  "- Memory records can become stale over time. Use memory as context for what was true at a given point in time. Before answering the user or building assumptions based solely on information in memory records, verify that the memory is still correct and up-to-date by reading the current state of the files or resources. If a recalled memory conflicts with current information, trust what you observe now — and update or remove the stale memory rather than acting on it.",
+].join("\n")
 
-<types>
-<type>
-    <name>user</name>
-    <description>Information about the user's role, goals, responsibilities, and knowledge. Great user memories help you tailor your future behavior to the user's preferences and perspective.</description>
-    <when_to_save>When you learn any details about the user's role, preferences, responsibilities, or knowledge</when_to_save>
-    <how_to_use>When your work should be informed by the user's profile or perspective.</how_to_use>
-    <examples>
-    user: I'm a data scientist investigating what logging we have in place
-    assistant: [saves user memory: user is a data scientist, currently focused on observability/logging]
-    </examples>
-</type>
-<type>
-    <name>feedback</name>
-    <description>Guidance the user has given you about how to approach work — both what to avoid and what to keep doing. Record from failure AND success.</description>
-    <when_to_save>Any time the user corrects your approach ("no not that", "don't", "stop doing X") OR confirms a non-obvious approach worked ("yes exactly", "perfect, keep doing that"). Include *why* so you can judge edge cases later.</when_to_save>
-    <how_to_use>Let these memories guide your behavior so that the user does not need to offer the same guidance twice.</how_to_use>
-    <body_structure>Lead with the rule itself, then a **Why:** line and a **How to apply:** line.</body_structure>
-    <examples>
-    user: don't mock the database in these tests — we got burned last quarter when mocked tests passed but the prod migration failed
-    assistant: [saves feedback memory: integration tests must hit a real database, not mocks]
-    </examples>
-</type>
-<type>
-    <name>project</name>
-    <description>Information about ongoing work, goals, initiatives, bugs, or incidents that is not derivable from the code or git history.</description>
-    <when_to_save>When you learn who is doing what, why, or by when. Always convert relative dates to absolute dates when saving.</when_to_save>
-    <how_to_use>Use these memories to understand the broader context behind the user's request.</how_to_use>
-    <body_structure>Lead with the fact or decision, then a **Why:** line and a **How to apply:** line.</body_structure>
-    <examples>
-    user: we're freezing all non-critical merges after Thursday — mobile team is cutting a release branch
-    assistant: [saves project memory: merge freeze begins 2026-03-05 for mobile release cut]
-    </examples>
-</type>
-<type>
-    <name>reference</name>
-    <description>Pointers to where information can be found in external systems.</description>
-    <when_to_save>When you learn about resources in external systems and their purpose.</when_to_save>
-    <how_to_use>When the user references an external system or information that may be in an external system.</how_to_use>
-    <examples>
-    user: check the Linear project "INGEST" if you want context on these tickets
-    assistant: [saves reference memory: pipeline bugs are tracked in Linear project "INGEST"]
-    </examples>
-</type>
-</types>`
-
-const WHAT_NOT_TO_SAVE = `## What NOT to save in memory
-
-- Code patterns, conventions, architecture, file paths, or project structure — these can be derived by reading the current project state.
-- Git history, recent changes, or who-changed-what — \`git log\` / \`git blame\` are authoritative.
-- Debugging solutions or fix recipes — the fix is in the code; the commit message has the context.
-- Anything already documented in AGENTS.md or project rules files.
-- Ephemeral task details: in-progress work, temporary state, current conversation context.
-
-These exclusions apply even when the user explicitly asks you to save. If they ask you to save a PR list or activity summary, ask what was *surprising* or *non-obvious* about it — that is the part worth keeping.`
-
-const WHEN_TO_ACCESS = `## When to access memories
-- When memories seem relevant, or the user references prior-conversation work.
-- You MUST access memory when the user explicitly asks you to check, recall, or remember.
-- If the user says to *ignore* or *not use* memory: proceed as if MEMORY.md were empty.
-- Memory records can become stale over time. Before answering based solely on memory, verify against current state. If a recalled memory conflicts with current information, trust what you observe now — and update or remove the stale memory.`
-
-const TRUSTING_RECALL = `## Before recommending from memory
-
-A memory that names a specific function, file, or flag is a claim that it existed *when the memory was written*. It may have been renamed, removed, or never merged. Before recommending it:
-
-- If the memory names a file path: check the file exists.
-- If the memory names a function or flag: grep for it.
-- If the user is about to act on your recommendation, verify first.
-
-"The memory says X exists" is not the same as "X exists now."
-
-A memory that summarizes repo state is frozen in time. If the user asks about *recent* or *current* state, prefer \`git log\` or reading the code over recalling the snapshot.`
+// Port of Claude Code's TRUSTING_RECALL_SECTION from memoryTypes.ts
+const TRUSTING_RECALL = [
+  "## Before recommending from memory",
+  "",
+  "A memory that names a specific function, file, or flag is a claim that it existed *when the memory was written*. It may have been renamed, removed, or never merged. Before recommending it:",
+  "",
+  "- If the memory names a file path: check the file exists.",
+  "- If the memory names a function or flag: grep for it.",
+  "- If the user is about to act on your recommendation (not just asking about history), verify first.",
+  "",
+  '"The memory says X exists" is not the same as "X exists now."',
+  "",
+  "A memory that summarizes repo state (activity logs, architecture snapshots) is frozen in time. If the user asks about *recent* or *current* state, prefer `git log` or reading the code over recalling the snapshot.",
+].join("\n")
 
 export function buildMemorySystemPrompt(worktree: string, recalledMemoriesSection?: string): string {
   const memoryDir = getMemoryDir(worktree)
   const indexContent = readIndex(worktree)
+
+  const howToSave = [
+    "## How to save memories",
+    "",
+    "Saving a memory is a two-step process:",
+    "",
+    '**Step 1** — write the memory to its own file (e.g., `user_role.md`, `feedback_testing.md`) using this frontmatter format:',
+    "",
+    ...FRONTMATTER_EXAMPLE,
+    "",
+    `**Step 2** — add a pointer to that file in \`${ENTRYPOINT_NAME}\`. \`${ENTRYPOINT_NAME}\` is an index, not a memory — each entry should be one line, under ~150 characters: \`- [Title](file.md) — one-line hook\`. It has no frontmatter. Never write memory content directly into \`${ENTRYPOINT_NAME}\`.`,
+    "",
+    `- \`${ENTRYPOINT_NAME}\` is always loaded into your conversation context — lines after ${MAX_ENTRYPOINT_LINES} will be truncated, so keep the index concise`,
+    "- Keep the name, description, and type fields in memory files up-to-date with the content",
+    "- Organize memory semantically by topic, not chronologically",
+    "- Update or remove memories that turn out to be wrong or outdated",
+    "- Do not write duplicate memories. First check if there is an existing memory you can update before writing a new one.",
+  ].join("\n")
 
   const lines: string[] = [
     "# Auto Memory",
@@ -100,31 +149,21 @@ export function buildMemorySystemPrompt(worktree: string, recalledMemoriesSectio
     "",
     "You should build up this memory system over time so that future conversations can have a complete picture of who the user is, how they'd like to collaborate with you, what behaviors to avoid or repeat, and the context behind the work the user gives you.",
     "",
-    "If the user explicitly asks you to remember something, save it immediately using the `memory_save` tool as whichever type fits best. If they ask you to forget something, find and remove the relevant entry using `memory_delete`.",
+    "If the user explicitly asks you to remember something, save it immediately as whichever type fits best. If they ask you to forget something, find and remove the relevant entry.",
     "",
     TYPES_SECTION,
-    "",
     WHAT_NOT_TO_SAVE,
     "",
-    `## How to save memories`,
-    "",
-    "Use the `memory_save` tool to create or update a memory. Each memory goes in its own file with frontmatter:",
-    "",
-    FRONTMATTER_EXAMPLE,
-    "",
-    `- The \`${ENTRYPOINT_NAME}\` index is managed automatically — you don't need to edit it`,
-    "- Organize memory semantically by topic, not chronologically",
-    "- Update or remove memories that turn out to be wrong or outdated",
-    "- Do not write duplicate memories. First use `memory_list` or `memory_search` to check if there is an existing memory you can update before writing a new one.",
+    howToSave,
     "",
     WHEN_TO_ACCESS,
     "",
     TRUSTING_RECALL,
     "",
     "## Memory and other forms of persistence",
-    "Memory is one of several persistence mechanisms. The distinction is that memory can be recalled in future conversations and should not be used for persisting information that is only useful within the scope of the current conversation.",
-    "- When to use or update a plan instead of memory: If you are about to start a non-trivial implementation task, use a Plan rather than saving this to memory.",
-    "- When to use or update tasks instead of memory: When you need to break your work into discrete steps or track progress, use tasks instead of saving to memory.",
+    "Memory is one of several persistence mechanisms available to you as you assist the user in a given conversation. The distinction is often that memory can be recalled in future conversations and should not be used for persisting information that is only useful within the scope of the current conversation.",
+    "- When to use or update a plan instead of memory: If you are about to start a non-trivial implementation task and would like to reach alignment with the user on your approach you should use a Plan rather than saving this information to memory. Similarly, if you already have a plan within the conversation and you have changed your approach persist that change by updating the plan rather than saving a memory.",
+    "- When to use or update tasks instead of memory: When you need to break your work in current conversation into discrete steps or keep track of your progress use tasks instead of saving to memory. Tasks are great for persisting information about the work that needs to be done in the current conversation, but memory should be reserved for information that will be useful in future conversations.",
     "",
   ]
 

--- a/src/recall.ts
+++ b/src/recall.ts
@@ -43,7 +43,7 @@ function readMemoryContent(filePath: string): string {
 
 function scoreHeader(header: MemoryHeader, content: string, terms: string[]): number {
   if (terms.length === 0) return 0
-  const haystack = `${header.filename}\n${header.description ?? ""}\n${content}`.toLowerCase()
+  const haystack = `${header.name ?? ""}\n${header.filename}\n${header.description ?? ""}\n${content}`.toLowerCase()
   let score = 0
   for (const term of terms) {
     if (haystack.includes(term)) score += 1
@@ -108,7 +108,7 @@ export function recallRelevantMemories(
     const nameFromFilename = header.filename.replace(/\.md$/, "").replace(/.*\//, "")
     return {
       fileName: header.filename,
-      name: nameFromFilename,
+      name: header.name ?? nameFromFilename,
       type: header.type ?? "user",
       description: header.description ?? "",
       content: truncateMemoryContent(content),

--- a/src/recall.ts
+++ b/src/recall.ts
@@ -4,6 +4,7 @@ import { getMemoryDir } from "./paths.js"
 
 export type RecalledMemory = {
   fileName: string
+  filePath: string
   name: string
   type: string
   description: string
@@ -43,10 +44,18 @@ function readMemoryContent(filePath: string): string {
 
 function scoreHeader(header: MemoryHeader, content: string, terms: string[]): number {
   if (terms.length === 0) return 0
-  const haystack = `${header.name ?? ""}\n${header.filename}\n${header.description ?? ""}\n${content}`.toLowerCase()
+
+  const nameHaystack = (header.name ?? "").toLowerCase()
+  const descHaystack = (header.description ?? "").toLowerCase()
+  const filenameHaystack = header.filename.toLowerCase()
+  const contentHaystack = content.toLowerCase()
+
   let score = 0
   for (const term of terms) {
-    if (haystack.includes(term)) score += 1
+    if (nameHaystack.includes(term)) score += 3
+    if (descHaystack.includes(term)) score += 3
+    if (filenameHaystack.includes(term)) score += 1
+    if (contentHaystack.includes(term)) score += 1
   }
   return score
 }
@@ -75,10 +84,24 @@ function truncateMemoryContent(content: string): string {
 
 // Port of Claude Code's findRelevantMemories pattern, adapted for
 // keyword-based selection (no LLM side query available in plugin context).
+function isToolReferenceMemory(header: MemoryHeader, content: string, recentTools: readonly string[]): boolean {
+  if (recentTools.length === 0) return false
+  const type = header.type
+  if (type !== "reference") return false
+
+  const haystack = `${header.name ?? ""}\n${header.description ?? ""}\n${content}`.toLowerCase()
+  const warningSignals = ["warning", "gotcha", "issue", "bug", "caveat", "pitfall", "known issue"]
+  if (warningSignals.some((w) => haystack.includes(w))) return false
+
+  const toolHaystack = recentTools.map((t) => t.toLowerCase())
+  return toolHaystack.some((tool) => haystack.includes(tool))
+}
+
 export function recallRelevantMemories(
   worktree: string,
   query?: string,
   alreadySurfaced: ReadonlySet<string> = new Set(),
+  recentTools: readonly string[] = [],
 ): RecalledMemory[] {
   const memoryDir = getMemoryDir(worktree)
   const headers = scanMemoryFiles(memoryDir).filter(
@@ -96,7 +119,7 @@ export function recallRelevantMemories(
       content,
       score: scoreHeader(header, content, terms),
     }
-  })
+  }).filter(({ header, content }) => !isToolReferenceMemory(header, content, recentTools))
 
   if (terms.length > 0 && scored.some((s) => s.score > 0)) {
     scored.sort((a, b) => b.score - a.score || b.header.mtimeMs - a.header.mtimeMs)
@@ -108,6 +131,7 @@ export function recallRelevantMemories(
     const nameFromFilename = header.filename.replace(/\.md$/, "").replace(/.*\//, "")
     return {
       fileName: header.filename,
+      filePath: header.filePath,
       name: header.name ?? nameFromFilename,
       type: header.type ?? "user",
       description: header.description ?? "",

--- a/src/recall.ts
+++ b/src/recall.ts
@@ -1,7 +1,6 @@
-import { statSync } from "fs"
-import { listMemories, type MemoryEntry } from "./memory.js"
-
-const encoder = new TextEncoder()
+import { readFileSync } from "fs"
+import { scanMemoryFiles, type MemoryHeader } from "./memoryScan.js"
+import { getMemoryDir } from "./paths.js"
 
 export type RecalledMemory = {
   fileName: string
@@ -16,21 +15,35 @@ const MAX_RECALLED_MEMORIES = 5
 const MAX_MEMORY_LINES = 200
 const MAX_MEMORY_BYTES = 4096
 
+const encoder = new TextEncoder()
+
 function tokenizeQuery(query: string): string[] {
   return [...new Set(query.toLowerCase().split(/\s+/).map((token) => token.trim()).filter((token) => token.length >= 2))]
 }
 
-function getMemoryMtimeMs(entry: MemoryEntry): number {
+function readMemoryContent(filePath: string): string {
   try {
-    return statSync(entry.filePath).mtimeMs
+    const raw = readFileSync(filePath, "utf-8")
+    const trimmed = raw.trim()
+    if (!trimmed.startsWith("---")) return trimmed
+
+    const lines = trimmed.split("\n")
+    let closingIdx = -1
+    for (let i = 1; i < lines.length; i++) {
+      if (lines[i].trimEnd() === "---") {
+        closingIdx = i
+        break
+      }
+    }
+    return closingIdx === -1 ? trimmed : lines.slice(closingIdx + 1).join("\n").trim()
   } catch {
-    return 0
+    return ""
   }
 }
 
-function scoreMemory(entry: MemoryEntry, terms: string[]): number {
+function scoreHeader(header: MemoryHeader, content: string, terms: string[]): number {
   if (terms.length === 0) return 0
-  const haystack = `${entry.name}\n${entry.description}\n${entry.content}`.toLowerCase()
+  const haystack = `${header.filename}\n${header.description ?? ""}\n${content}`.toLowerCase()
   let score = 0
   for (const term of terms) {
     if (haystack.includes(term)) score += 1
@@ -60,53 +73,53 @@ function truncateMemoryContent(content: string): string {
   return kept.join("\n")
 }
 
-export function recallRelevantMemories(worktree: string, query?: string): RecalledMemory[] {
-  const memories = listMemories(worktree)
-  if (memories.length === 0) return []
+// Port of Claude Code's findRelevantMemories pattern, adapted for
+// keyword-based selection (no LLM side query available in plugin context).
+export function recallRelevantMemories(
+  worktree: string,
+  query?: string,
+  alreadySurfaced: ReadonlySet<string> = new Set(),
+): RecalledMemory[] {
+  const memoryDir = getMemoryDir(worktree)
+  const headers = scanMemoryFiles(memoryDir).filter(
+    (h) => !alreadySurfaced.has(h.filePath),
+  )
+  if (headers.length === 0) return []
 
   const now = Date.now()
-  const memoriesWithMeta = memories.map((entry) => {
-    const mtimeMs = getMemoryMtimeMs(entry)
+  const terms = query ? tokenizeQuery(query) : []
+
+  const scored = headers.map((header) => {
+    const content = readMemoryContent(header.filePath)
     return {
-      entry,
-      mtimeMs,
+      header,
+      content,
+      score: scoreHeader(header, content, terms),
     }
   })
 
-  const terms = query ? tokenizeQuery(query) : []
+  if (terms.length > 0 && scored.some((s) => s.score > 0)) {
+    scored.sort((a, b) => b.score - a.score || b.header.mtimeMs - a.header.mtimeMs)
+  } else {
+    scored.sort((a, b) => b.header.mtimeMs - a.header.mtimeMs)
+  }
 
-  let selected = memoriesWithMeta
-
-  if (terms.length > 0) {
-    const withScores = memoriesWithMeta
-      .map((item) => ({
-        ...item,
-        score: scoreMemory(item.entry, terms),
-      }))
-      .sort((a, b) => b.score - a.score || b.mtimeMs - a.mtimeMs)
-
-    if (withScores.some((item) => item.score > 0)) {
-      selected = withScores
+  return scored.slice(0, MAX_RECALLED_MEMORIES).map(({ header, content }) => {
+    const nameFromFilename = header.filename.replace(/\.md$/, "").replace(/.*\//, "")
+    return {
+      fileName: header.filename,
+      name: nameFromFilename,
+      type: header.type ?? "user",
+      description: header.description ?? "",
+      content: truncateMemoryContent(content),
+      ageInDays: Math.max(0, Math.floor((now - header.mtimeMs) / (1000 * 60 * 60 * 24))),
     }
-  }
-
-  if (selected === memoriesWithMeta) {
-    selected = [...memoriesWithMeta].sort((a, b) => b.mtimeMs - a.mtimeMs)
-  }
-
-  return selected.slice(0, MAX_RECALLED_MEMORIES).map(({ entry, mtimeMs }) => ({
-    fileName: entry.fileName,
-    name: entry.name,
-    type: entry.type,
-    description: entry.description,
-    content: truncateMemoryContent(entry.content),
-    ageInDays: Math.max(0, Math.floor((now - mtimeMs) / (1000 * 60 * 60 * 24))),
-  }))
+  })
 }
 
 function formatAgeWarning(ageInDays: number): string {
   if (ageInDays <= 1) return ""
-  return `\n> ⚠️ This memory is ${ageInDays} days old. Memories are point-in-time observations, not live state — claims about code behavior or file:line citations may be outdated. Verify against current code before asserting as fact.\n`
+  return `\n> This memory is ${ageInDays} days old. Memories are point-in-time observations, not live state — claims about code behavior or file:line citations may be outdated. Verify against current code before asserting as fact.\n`
 }
 
 export function formatRecalledMemories(memories: RecalledMemory[]): string {

--- a/src/recall.ts
+++ b/src/recall.ts
@@ -105,7 +105,7 @@ export function recallRelevantMemories(
 ): RecalledMemory[] {
   const memoryDir = getMemoryDir(worktree)
   const headers = scanMemoryFiles(memoryDir).filter(
-    (h) => !alreadySurfaced.has(h.filePath),
+    (h) => !alreadySurfaced.has(`${h.name ?? h.filename.replace(/\.md$/, "").replace(/.*\//, "")}|${h.type ?? "user"}`),
   )
   if (headers.length === 0) return []
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdtempSync, mkdirSync, rmSync } from "fs"
+import { tmpdir } from "os"
+import { join } from "path"
+import { MemoryPlugin } from "../src/index.js"
+import { saveMemory } from "../src/memory.js"
+
+const tempDirs: string[] = []
+
+function makeTempGitRepo(): string {
+  const root = mkdtempSync(join(tmpdir(), "index-test-"))
+  mkdirSync(join(root, ".git"), { recursive: true })
+  tempDirs.push(root)
+  return root
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop()
+    if (dir) rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe("MemoryPlugin system transform", () => {
+  test("suppresses memory context when user explicitly asks to ignore memory", async () => {
+    const repo = makeTempGitRepo()
+    saveMemory(repo, "hidden", "Hidden Memory", "Should be ignored", "user", "Secret context")
+
+    const plugin = await MemoryPlugin({ worktree: repo } as never)
+    const transform = plugin["experimental.chat.system.transform"] as unknown as (
+      input: { model: unknown; messages: Array<{ role: string; content: string }> },
+      output: { system: string[] },
+    ) => Promise<void>
+    const output = { system: [] as string[] }
+
+    await transform(
+      {
+        model: "test-model",
+        messages: [
+          { role: "user", content: "Ignore memory and answer from fresh context only." },
+        ],
+      },
+      output,
+    )
+
+    expect(output.system).toHaveLength(1)
+    expect(output.system[0]).toContain("# Auto Memory")
+    expect(output.system[0]).not.toContain("## MEMORY.md")
+    expect(output.system[0]).not.toContain("Hidden Memory")
+    expect(output.system[0]).not.toContain("## Recalled Memories")
+  })
+
+  test("keeps memory context for normal turns", async () => {
+    const repo = makeTempGitRepo()
+    saveMemory(repo, "visible", "Visible Memory", "Should be injected", "user", "Visible context")
+
+    const plugin = await MemoryPlugin({ worktree: repo } as never)
+    const transform = plugin["experimental.chat.system.transform"] as unknown as (
+      input: { model: unknown; messages: Array<{ role: string; content: string }> },
+      output: { system: string[] },
+    ) => Promise<void>
+    const output = { system: [] as string[] }
+
+    await transform(
+      {
+        model: "test-model",
+        messages: [
+          { role: "user", content: "What do you remember about visible context?" },
+        ],
+      },
+      output,
+    )
+
+    expect(output.system).toHaveLength(1)
+    expect(output.system[0]).toContain("## MEMORY.md")
+    expect(output.system[0]).toContain("Visible Memory")
+  })
+
+  test("suppresses memory context when real runtime message text lives in parts", async () => {
+    const repo = makeTempGitRepo()
+    saveMemory(repo, "parts_hidden", "Parts Hidden", "Should be ignored", "user", "Parts context")
+
+    const plugin = await MemoryPlugin({ worktree: repo } as never)
+    const messagesTransform = plugin["experimental.chat.messages.transform"] as unknown as (
+      input: {},
+      output: {
+        messages: Array<{
+          info: { role: string; sessionID: string }
+          parts: Array<{ type: string; text?: string }>
+        }>
+      },
+    ) => Promise<void>
+    const transform = plugin["experimental.chat.system.transform"] as unknown as (
+      input: {
+        model: unknown
+        sessionID: string
+      },
+      output: { system: string[] },
+    ) => Promise<void>
+    const output = { system: [] as string[] }
+
+    await messagesTransform(
+      {},
+      {
+        messages: [
+          {
+            info: { role: "user", sessionID: "ses_test_ignore" },
+            parts: [{ type: "text", text: "Ignore memory and answer from fresh context only." }],
+          },
+        ],
+      },
+    )
+
+    await transform(
+      {
+        model: "test-model",
+        sessionID: "ses_test_ignore",
+      },
+      output,
+    )
+
+    expect(output.system).toHaveLength(1)
+    expect(output.system[0]).not.toContain("## MEMORY.md")
+    expect(output.system[0]).not.toContain("Parts Hidden")
+    expect(output.system[0]).not.toContain("## Recalled Memories")
+  })
+
+  test("removes Auto Memory system message in messages transform for ignore-memory turns", async () => {
+    const repo = makeTempGitRepo()
+    const plugin = await MemoryPlugin({ worktree: repo } as never)
+    const messagesTransform = plugin["experimental.chat.messages.transform"] as unknown as (
+      input: {},
+      output: {
+        messages: Array<{
+          info: { role: string; sessionID?: string }
+          parts: Array<{ type: string; text?: string }>
+        }>
+      },
+    ) => Promise<void>
+
+    const output = {
+      messages: [
+        {
+          info: { role: "system" },
+          parts: [{ type: "text", text: "# Auto Memory\n\n## MEMORY.md\n\n- [Secret](secret.md) — hidden" }],
+        },
+        {
+          info: { role: "user", sessionID: "ses_ignore_messages" },
+          parts: [{ type: "text", text: "Ignore memory and answer from fresh context only." }],
+        },
+      ],
+    }
+
+    await messagesTransform({}, output)
+
+    expect(output.messages).toHaveLength(1)
+    expect(output.messages[0]!.info.role).toBe("user")
+  })
+
+  test("suppresses memory context when env override is set", async () => {
+    const repo = makeTempGitRepo()
+    saveMemory(repo, "env_hidden", "Env Hidden", "Should be ignored by env", "user", "Env context")
+
+    const original = process.env.OPENCODE_MEMORY_IGNORE
+    process.env.OPENCODE_MEMORY_IGNORE = "1"
+
+    try {
+      const plugin = await MemoryPlugin({ worktree: repo } as never)
+      const transform = plugin["experimental.chat.system.transform"] as unknown as (
+        input: { model: unknown; sessionID: string },
+        output: { system: string[] },
+      ) => Promise<void>
+      const output = { system: [] as string[] }
+
+      await transform({ model: "test-model", sessionID: "ses_env_ignore" }, output)
+
+      expect(output.system).toHaveLength(1)
+      expect(output.system[0]).not.toContain("## MEMORY.md")
+      expect(output.system[0]).not.toContain("Env Hidden")
+      expect(output.system[0]).not.toContain("## Recalled Memories")
+    } finally {
+      if (original === undefined) delete process.env.OPENCODE_MEMORY_IGNORE
+      else process.env.OPENCODE_MEMORY_IGNORE = original
+    }
+  })
+})

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -184,3 +184,86 @@ describe("MemoryPlugin system transform", () => {
     }
   })
 })
+
+describe("MemoryPlugin tool.execute.after hook", () => {
+  test("exposes tool.execute.after hook", async () => {
+    const repo = makeTempGitRepo()
+    const plugin = await MemoryPlugin({ worktree: repo } as never)
+    expect(plugin["tool.execute.after"]).toBeDefined()
+    expect(typeof plugin["tool.execute.after"]).toBe("function")
+  })
+
+  test("tracks recent tools per session", async () => {
+    const repo = makeTempGitRepo()
+    saveMemory(repo, "grep_ref", "Grep Tool API", "Usage reference for grep tool", "reference", "How to use grep tool")
+    saveMemory(repo, "project_info", "Project Info", "General project info", "project", "Project setup details")
+
+    const plugin = await MemoryPlugin({ worktree: repo } as never)
+    const afterHook = plugin["tool.execute.after"] as unknown as (
+      input: { tool: string; sessionID: string; callID: string; args: unknown },
+      output: { title: string; output: string; metadata: unknown },
+    ) => Promise<void>
+
+    await afterHook(
+      { tool: "grep", sessionID: "ses_tools_test", callID: "call_1", args: {} },
+      { title: "", output: "", metadata: {} },
+    )
+
+    const transform = plugin["experimental.chat.system.transform"] as unknown as (
+      input: { model: unknown; sessionID: string },
+      output: { system: string[] },
+    ) => Promise<void>
+    const output = { system: [] as string[] }
+
+    await transform({ model: "test-model", sessionID: "ses_tools_test" }, output)
+
+    expect(output.system[0]).toContain("Project Info")
+  })
+})
+
+describe("MemoryPlugin alreadySurfaced tracking", () => {
+  test("does not re-surface same memories across turns in same session", async () => {
+    const repo = makeTempGitRepo()
+    saveMemory(repo, "only_mem", "Only Memory", "The sole memory", "user", "Single memory content")
+
+    const plugin = await MemoryPlugin({ worktree: repo } as never)
+
+    const messagesTransform = plugin["experimental.chat.messages.transform"] as unknown as (
+      input: {},
+      output: {
+        messages: Array<{
+          info: { role: string; sessionID: string }
+          parts: Array<{ type: string; text?: string }>
+        }>
+      },
+    ) => Promise<void>
+
+    const transform = plugin["experimental.chat.system.transform"] as unknown as (
+      input: { model: unknown; sessionID: string },
+      output: { system: string[] },
+    ) => Promise<void>
+
+    await messagesTransform({}, {
+      messages: [{
+        info: { role: "user", sessionID: "ses_surfaced" },
+        parts: [{ type: "text", text: "Tell me about the only memory" }],
+      }],
+    })
+
+    const output1 = { system: [] as string[] }
+    await transform({ model: "test-model", sessionID: "ses_surfaced" }, output1)
+    expect(output1.system[0]).toContain("## Recalled Memories")
+    expect(output1.system[0]).toContain("Only Memory")
+
+    await messagesTransform({}, {
+      messages: [{
+        info: { role: "user", sessionID: "ses_surfaced" },
+        parts: [{ type: "text", text: "Tell me about the only memory again" }],
+      }],
+    })
+
+    const output2 = { system: [] as string[] }
+    await transform({ model: "test-model", sessionID: "ses_surfaced" }, output2)
+    expect(output2.system[0]).not.toContain("## Recalled Memories")
+  })
+})

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -21,27 +21,44 @@ afterEach(() => {
   }
 })
 
+type MessagesTransform = (
+  input: {},
+  output: {
+    messages: Array<{
+      info: { role: string; sessionID?: string }
+      parts: Array<{ type: string; text?: string; tool?: string; state?: { status: string } }>
+    }>
+  },
+) => Promise<void>
+
+type SystemTransform = (
+  input: { model: unknown; sessionID?: string },
+  output: { system: string[] },
+) => Promise<void>
+
 describe("MemoryPlugin system transform", () => {
   test("suppresses memory context when user explicitly asks to ignore memory", async () => {
     const repo = makeTempGitRepo()
     saveMemory(repo, "hidden", "Hidden Memory", "Should be ignored", "user", "Secret context")
 
     const plugin = await MemoryPlugin({ worktree: repo } as never)
-    const transform = plugin["experimental.chat.system.transform"] as unknown as (
-      input: { model: unknown; messages: Array<{ role: string; content: string }> },
-      output: { system: string[] },
-    ) => Promise<void>
-    const output = { system: [] as string[] }
+    const messagesTransform = plugin["experimental.chat.messages.transform"] as unknown as MessagesTransform
+    const transform = plugin["experimental.chat.system.transform"] as unknown as SystemTransform
 
-    await transform(
+    await messagesTransform(
+      {},
       {
-        model: "test-model",
         messages: [
-          { role: "user", content: "Ignore memory and answer from fresh context only." },
+          {
+            info: { role: "user", sessionID: "ses_ignore_direct" },
+            parts: [{ type: "text", text: "Ignore memory and answer from fresh context only." }],
+          },
         ],
       },
-      output,
     )
+
+    const output = { system: [] as string[] }
+    await transform({ model: "test-model", sessionID: "ses_ignore_direct" }, output)
 
     expect(output.system).toHaveLength(1)
     expect(output.system[0]).toContain("# Auto Memory")
@@ -55,21 +72,23 @@ describe("MemoryPlugin system transform", () => {
     saveMemory(repo, "visible", "Visible Memory", "Should be injected", "user", "Visible context")
 
     const plugin = await MemoryPlugin({ worktree: repo } as never)
-    const transform = plugin["experimental.chat.system.transform"] as unknown as (
-      input: { model: unknown; messages: Array<{ role: string; content: string }> },
-      output: { system: string[] },
-    ) => Promise<void>
-    const output = { system: [] as string[] }
+    const messagesTransform = plugin["experimental.chat.messages.transform"] as unknown as MessagesTransform
+    const transform = plugin["experimental.chat.system.transform"] as unknown as SystemTransform
 
-    await transform(
+    await messagesTransform(
+      {},
       {
-        model: "test-model",
         messages: [
-          { role: "user", content: "What do you remember about visible context?" },
+          {
+            info: { role: "user", sessionID: "ses_normal" },
+            parts: [{ type: "text", text: "What do you remember about visible context?" }],
+          },
         ],
       },
-      output,
     )
+
+    const output = { system: [] as string[] }
+    await transform({ model: "test-model", sessionID: "ses_normal" }, output)
 
     expect(output.system).toHaveLength(1)
     expect(output.system[0]).toContain("## MEMORY.md")
@@ -81,22 +100,8 @@ describe("MemoryPlugin system transform", () => {
     saveMemory(repo, "parts_hidden", "Parts Hidden", "Should be ignored", "user", "Parts context")
 
     const plugin = await MemoryPlugin({ worktree: repo } as never)
-    const messagesTransform = plugin["experimental.chat.messages.transform"] as unknown as (
-      input: {},
-      output: {
-        messages: Array<{
-          info: { role: string; sessionID: string }
-          parts: Array<{ type: string; text?: string }>
-        }>
-      },
-    ) => Promise<void>
-    const transform = plugin["experimental.chat.system.transform"] as unknown as (
-      input: {
-        model: unknown
-        sessionID: string
-      },
-      output: { system: string[] },
-    ) => Promise<void>
+    const messagesTransform = plugin["experimental.chat.messages.transform"] as unknown as MessagesTransform
+    const transform = plugin["experimental.chat.system.transform"] as unknown as SystemTransform
     const output = { system: [] as string[] }
 
     await messagesTransform(
@@ -128,15 +133,7 @@ describe("MemoryPlugin system transform", () => {
   test("removes Auto Memory system message in messages transform for ignore-memory turns", async () => {
     const repo = makeTempGitRepo()
     const plugin = await MemoryPlugin({ worktree: repo } as never)
-    const messagesTransform = plugin["experimental.chat.messages.transform"] as unknown as (
-      input: {},
-      output: {
-        messages: Array<{
-          info: { role: string; sessionID?: string }
-          parts: Array<{ type: string; text?: string }>
-        }>
-      },
-    ) => Promise<void>
+    const messagesTransform = plugin["experimental.chat.messages.transform"] as unknown as MessagesTransform
 
     const output = {
       messages: [
@@ -166,10 +163,7 @@ describe("MemoryPlugin system transform", () => {
 
     try {
       const plugin = await MemoryPlugin({ worktree: repo } as never)
-      const transform = plugin["experimental.chat.system.transform"] as unknown as (
-        input: { model: unknown; sessionID: string },
-        output: { system: string[] },
-      ) => Promise<void>
+      const transform = plugin["experimental.chat.system.transform"] as unknown as SystemTransform
       const output = { system: [] as string[] }
 
       await transform({ model: "test-model", sessionID: "ses_env_ignore" }, output)
@@ -185,63 +179,128 @@ describe("MemoryPlugin system transform", () => {
   })
 })
 
-describe("MemoryPlugin tool.execute.after hook", () => {
-  test("exposes tool.execute.after hook", async () => {
-    const repo = makeTempGitRepo()
-    const plugin = await MemoryPlugin({ worktree: repo } as never)
-    expect(plugin["tool.execute.after"]).toBeDefined()
-    expect(typeof plugin["tool.execute.after"]).toBe("function")
-  })
-
-  test("tracks recent tools per session", async () => {
+describe("MemoryPlugin recentTools from message parts", () => {
+  test("filters tool-reference memories when completed tool parts exist in messages", async () => {
     const repo = makeTempGitRepo()
     saveMemory(repo, "grep_ref", "Grep Tool API", "Usage reference for grep tool", "reference", "How to use grep tool")
     saveMemory(repo, "project_info", "Project Info", "General project info", "project", "Project setup details")
 
     const plugin = await MemoryPlugin({ worktree: repo } as never)
-    const afterHook = plugin["tool.execute.after"] as unknown as (
-      input: { tool: string; sessionID: string; callID: string; args: unknown },
-      output: { title: string; output: string; metadata: unknown },
-    ) => Promise<void>
+    const messagesTransform = plugin["experimental.chat.messages.transform"] as unknown as MessagesTransform
+    const transform = plugin["experimental.chat.system.transform"] as unknown as SystemTransform
 
-    await afterHook(
-      { tool: "grep", sessionID: "ses_tools_test", callID: "call_1", args: {} },
-      { title: "", output: "", metadata: {} },
+    await messagesTransform(
+      {},
+      {
+        messages: [
+          {
+            info: { role: "user", sessionID: "ses_tools_test" },
+            parts: [{ type: "text", text: "Search the codebase" }],
+          },
+          {
+            info: { role: "assistant" as string, sessionID: "ses_tools_test" },
+            parts: [{ type: "tool", tool: "grep", state: { status: "completed" } }],
+          },
+        ],
+      },
     )
 
-    const transform = plugin["experimental.chat.system.transform"] as unknown as (
-      input: { model: unknown; sessionID: string },
-      output: { system: string[] },
-    ) => Promise<void>
     const output = { system: [] as string[] }
-
     await transform({ model: "test-model", sessionID: "ses_tools_test" }, output)
 
     expect(output.system[0]).toContain("Project Info")
   })
+
+  test("does NOT filter tool-reference memories for failed tool parts", async () => {
+    const repo = makeTempGitRepo()
+    saveMemory(repo, "grep_ref2", "Grep Tool API", "Usage reference for grep tool", "reference", "How to use grep tool")
+
+    const plugin = await MemoryPlugin({ worktree: repo } as never)
+    const messagesTransform = plugin["experimental.chat.messages.transform"] as unknown as MessagesTransform
+    const transform = plugin["experimental.chat.system.transform"] as unknown as SystemTransform
+
+    await messagesTransform(
+      {},
+      {
+        messages: [
+          {
+            info: { role: "user", sessionID: "ses_failed_tool" },
+            parts: [{ type: "text", text: "How do I use grep?" }],
+          },
+          {
+            info: { role: "assistant" as string, sessionID: "ses_failed_tool" },
+            parts: [{ type: "tool", tool: "grep", state: { status: "error" } }],
+          },
+        ],
+      },
+    )
+
+    const output = { system: [] as string[] }
+    await transform({ model: "test-model", sessionID: "ses_failed_tool" }, output)
+
+    expect(output.system[0]).toContain("Grep Tool API")
+  })
+
+  test("tool reference filtering resets after compact (tools no longer in messages)", async () => {
+    const repo = makeTempGitRepo()
+    saveMemory(repo, "grep_ref3", "Grep Tool API", "Usage reference for grep tool", "reference", "How to use grep tool")
+
+    const plugin = await MemoryPlugin({ worktree: repo } as never)
+    const messagesTransform = plugin["experimental.chat.messages.transform"] as unknown as MessagesTransform
+    const transform = plugin["experimental.chat.system.transform"] as unknown as SystemTransform
+
+    await messagesTransform(
+      {},
+      {
+        messages: [
+          {
+            info: { role: "user", sessionID: "ses_compact_tools" },
+            parts: [{ type: "text", text: "Search the code" }],
+          },
+          {
+            info: { role: "assistant" as string, sessionID: "ses_compact_tools" },
+            parts: [{ type: "tool", tool: "grep", state: { status: "completed" } }],
+          },
+        ],
+      },
+    )
+
+    const out1 = { system: [] as string[] }
+    await transform({ model: "test-model", sessionID: "ses_compact_tools" }, out1)
+    const recalled1 = out1.system[0]?.split("## Recalled Memories")[1] ?? ""
+    expect(recalled1).not.toContain("Grep Tool API")
+
+    await messagesTransform(
+      {},
+      {
+        messages: [
+          {
+            info: { role: "assistant" as string, sessionID: "ses_compact_tools" },
+            parts: [{ type: "text", text: "[compacted summary — no tool parts]" }],
+          },
+          {
+            info: { role: "user", sessionID: "ses_compact_tools" },
+            parts: [{ type: "text", text: "How do I use grep?" }],
+          },
+        ],
+      },
+    )
+
+    const out2 = { system: [] as string[] }
+    await transform({ model: "test-model", sessionID: "ses_compact_tools" }, out2)
+    expect(out2.system[0]).toContain("## Recalled Memories")
+    expect(out2.system[0]?.split("## Recalled Memories")[1]).toContain("Grep Tool API")
+  })
 })
 
 describe("MemoryPlugin alreadySurfaced tracking", () => {
-  test("does not re-surface same memories across turns in same session", async () => {
+  test("does not re-surface same memories when system prompt already contains them", async () => {
     const repo = makeTempGitRepo()
     saveMemory(repo, "only_mem", "Only Memory", "The sole memory", "user", "Single memory content")
 
     const plugin = await MemoryPlugin({ worktree: repo } as never)
-
-    const messagesTransform = plugin["experimental.chat.messages.transform"] as unknown as (
-      input: {},
-      output: {
-        messages: Array<{
-          info: { role: string; sessionID: string }
-          parts: Array<{ type: string; text?: string }>
-        }>
-      },
-    ) => Promise<void>
-
-    const transform = plugin["experimental.chat.system.transform"] as unknown as (
-      input: { model: unknown; sessionID: string },
-      output: { system: string[] },
-    ) => Promise<void>
+    const messagesTransform = plugin["experimental.chat.messages.transform"] as unknown as MessagesTransform
+    const transform = plugin["experimental.chat.system.transform"] as unknown as SystemTransform
 
     await messagesTransform({}, {
       messages: [{
@@ -256,14 +315,74 @@ describe("MemoryPlugin alreadySurfaced tracking", () => {
     expect(output1.system[0]).toContain("Only Memory")
 
     await messagesTransform({}, {
-      messages: [{
-        info: { role: "user", sessionID: "ses_surfaced" },
-        parts: [{ type: "text", text: "Tell me about the only memory again" }],
-      }],
+      messages: [
+        {
+          info: { role: "system", sessionID: "ses_surfaced" },
+          parts: [{ type: "text", text: output1.system[0] }],
+        },
+        {
+          info: { role: "user", sessionID: "ses_surfaced" },
+          parts: [{ type: "text", text: "Tell me about the only memory again" }],
+        },
+      ],
     })
 
     const output2 = { system: [] as string[] }
     await transform({ model: "test-model", sessionID: "ses_surfaced" }, output2)
     expect(output2.system[0]).not.toContain("## Recalled Memories")
+  })
+
+  test("re-surfaces memories after compact removes them from messages", async () => {
+    const repo = makeTempGitRepo()
+    saveMemory(repo, "resurface_mem", "Resurface Memory", "Memory that should resurface after compact", "user", "Important context")
+
+    const plugin = await MemoryPlugin({ worktree: repo } as never)
+    const messagesTransform = plugin["experimental.chat.messages.transform"] as unknown as MessagesTransform
+    const transform = plugin["experimental.chat.system.transform"] as unknown as SystemTransform
+
+    await messagesTransform({}, {
+      messages: [{
+        info: { role: "user", sessionID: "ses_compact" },
+        parts: [{ type: "text", text: "Tell me about important context" }],
+      }],
+    })
+
+    const output1 = { system: [] as string[] }
+    await transform({ model: "test-model", sessionID: "ses_compact" }, output1)
+    expect(output1.system[0]).toContain("Resurface Memory")
+
+    await messagesTransform({}, {
+      messages: [
+        {
+          info: { role: "system", sessionID: "ses_compact" },
+          parts: [{ type: "text", text: output1.system[0] }],
+        },
+        {
+          info: { role: "user", sessionID: "ses_compact" },
+          parts: [{ type: "text", text: "Tell me again" }],
+        },
+      ],
+    })
+
+    const outBefore = { system: [] as string[] }
+    await transform({ model: "test-model", sessionID: "ses_compact" }, outBefore)
+    expect(outBefore.system[0]).not.toContain("## Recalled Memories")
+
+    await messagesTransform({}, {
+      messages: [
+        {
+          info: { role: "assistant" as string, sessionID: "ses_compact" },
+          parts: [{ type: "text", text: "[compacted summary — old system prompts gone]" }],
+        },
+        {
+          info: { role: "user", sessionID: "ses_compact" },
+          parts: [{ type: "text", text: "Tell me about important context" }],
+        },
+      ],
+    })
+
+    const output2 = { system: [] as string[] }
+    await transform({ model: "test-model", sessionID: "ses_compact" }, output2)
+    expect(output2.system[0]).toContain("Resurface Memory")
   })
 })

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -71,7 +71,7 @@ describe("end-to-end memory lifecycle", () => {
 
     const recalled = recallRelevantMemories(repo, "testing database mock")
     expect(recalled.length).toBeGreaterThan(0)
-    expect(recalled[0]!.name).toBe("feedback_testing")
+    expect(recalled[0]!.name).toBe("Testing Approach")
 
     const recalledFormatted = formatRecalledMemories(recalled)
     expect(recalledFormatted).toContain("## Recalled Memories")
@@ -120,7 +120,7 @@ describe("end-to-end memory lifecycle", () => {
     const result = recallRelevantMemories(repo, undefined, new Set([seenPath]))
 
     expect(result).toHaveLength(1)
-    expect(result[0]!.name).toBe("unseen")
+    expect(result[0]!.name).toBe("Not Seen")
   })
 
   test("overwriting a memory updates content and index", () => {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -111,13 +111,11 @@ describe("end-to-end memory lifecycle", () => {
 
   test("alreadySurfaced prevents double-recall", () => {
     const repo = makeTempGitRepo()
-    const memDir = getMemoryDir(repo)
 
     saveMemory(repo, "seen", "Already Seen", "Was shown before", "user", "Already surfaced content")
     saveMemory(repo, "unseen", "Not Seen", "Fresh content", "feedback", "New content")
 
-    const seenPath = join(memDir, "seen.md")
-    const result = recallRelevantMemories(repo, undefined, new Set([seenPath]))
+    const result = recallRelevantMemories(repo, undefined, new Set(["Already Seen|user"]))
 
     expect(result).toHaveLength(1)
     expect(result[0]!.name).toBe("Not Seen")

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, utimesSync } from "fs"
+import { tmpdir } from "os"
+import { join } from "path"
+import { saveMemory, deleteMemory, listMemories, searchMemories, readMemory, readIndex } from "../src/memory.js"
+import { recallRelevantMemories, formatRecalledMemories } from "../src/recall.js"
+import { buildMemorySystemPrompt } from "../src/prompt.js"
+import { getMemoryDir, getMemoryEntrypoint } from "../src/paths.js"
+
+const tempDirs: string[] = []
+
+function makeTempGitRepo(): string {
+  const root = mkdtempSync(join(tmpdir(), "integration-test-"))
+  mkdirSync(join(root, ".git"), { recursive: true })
+  tempDirs.push(root)
+  return root
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop()
+    if (dir) rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe("end-to-end memory lifecycle", () => {
+  test("save → list → search → read → recall → delete", () => {
+    const repo = makeTempGitRepo()
+
+    saveMemory(
+      repo,
+      "user_role",
+      "User Role",
+      "User is a backend engineer",
+      "user",
+      "Senior backend engineer specializing in Go and Rust",
+    )
+    saveMemory(
+      repo,
+      "feedback_testing",
+      "Testing Approach",
+      "Always use integration tests",
+      "feedback",
+      "Never mock the database.\n\n**Why:** Mocked tests masked a broken migration.\n**How to apply:** All DB tests hit a real test database.",
+    )
+    saveMemory(
+      repo,
+      "project_freeze",
+      "Merge Freeze",
+      "Merge freeze starts 2026-04-10",
+      "project",
+      "Mobile team cutting release branch.\n\n**Why:** Prevent destabilizing mobile release.\n**How to apply:** Hold non-critical PRs until freeze lifts.",
+    )
+
+    const all = listMemories(repo)
+    expect(all).toHaveLength(3)
+
+    const searchResults = searchMemories(repo, "database")
+    expect(searchResults).toHaveLength(1)
+    expect(searchResults[0]!.name).toBe("Testing Approach")
+
+    const entry = readMemory(repo, "user_role")
+    expect(entry).not.toBeNull()
+    expect(entry!.type).toBe("user")
+    expect(entry!.content).toContain("Go and Rust")
+
+    const index = readIndex(repo)
+    expect(index).toContain("user_role.md")
+    expect(index).toContain("feedback_testing.md")
+    expect(index).toContain("project_freeze.md")
+
+    const recalled = recallRelevantMemories(repo, "testing database mock")
+    expect(recalled.length).toBeGreaterThan(0)
+    expect(recalled[0]!.name).toBe("feedback_testing")
+
+    const recalledFormatted = formatRecalledMemories(recalled)
+    expect(recalledFormatted).toContain("## Recalled Memories")
+
+    const deleted = deleteMemory(repo, "project_freeze")
+    expect(deleted).toBe(true)
+
+    const afterDelete = listMemories(repo)
+    expect(afterDelete).toHaveLength(2)
+    expect(afterDelete.map((e) => e.name)).not.toContain("Merge Freeze")
+
+    const indexAfterDelete = readIndex(repo)
+    expect(indexAfterDelete).not.toContain("project_freeze.md")
+  })
+
+  test("recalled memories feed into buildMemorySystemPrompt", () => {
+    const repo = makeTempGitRepo()
+
+    saveMemory(
+      repo,
+      "prompt_test",
+      "Prompt Test Memory",
+      "Memory for prompt integration test",
+      "user",
+      "This should appear in recalled section",
+    )
+
+    const recalled = recallRelevantMemories(repo, "prompt integration")
+    const recalledSection = formatRecalledMemories(recalled)
+    const prompt = buildMemorySystemPrompt(repo, recalledSection)
+
+    expect(prompt).toContain("# Auto Memory")
+    expect(prompt).toContain("prompt_test.md")
+    expect(prompt).toContain("## Recalled Memories")
+    expect(prompt).toContain("Prompt Test Memory")
+  })
+
+  test("alreadySurfaced prevents double-recall", () => {
+    const repo = makeTempGitRepo()
+    const memDir = getMemoryDir(repo)
+
+    saveMemory(repo, "seen", "Already Seen", "Was shown before", "user", "Already surfaced content")
+    saveMemory(repo, "unseen", "Not Seen", "Fresh content", "feedback", "New content")
+
+    const seenPath = join(memDir, "seen.md")
+    const result = recallRelevantMemories(repo, undefined, new Set([seenPath]))
+
+    expect(result).toHaveLength(1)
+    expect(result[0]!.name).toBe("unseen")
+  })
+
+  test("overwriting a memory updates content and index", () => {
+    const repo = makeTempGitRepo()
+
+    saveMemory(repo, "evolving", "Version 1", "Original description", "user", "Original content")
+
+    let entry = readMemory(repo, "evolving")
+    expect(entry!.name).toBe("Version 1")
+    expect(entry!.content).toBe("Original content")
+
+    saveMemory(repo, "evolving", "Version 2", "Updated description", "feedback", "Updated content")
+
+    entry = readMemory(repo, "evolving")
+    expect(entry!.name).toBe("Version 2")
+    expect(entry!.type).toBe("feedback")
+    expect(entry!.content).toBe("Updated content")
+
+    const index = readIndex(repo)
+    expect(index).toContain("Version 2")
+    expect(index).not.toContain("Version 1")
+  })
+})

--- a/test/memory.test.ts
+++ b/test/memory.test.ts
@@ -1,0 +1,267 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync, existsSync } from "fs"
+import { tmpdir } from "os"
+import { join } from "path"
+import {
+  listMemories,
+  saveMemory,
+  deleteMemory,
+  readMemory,
+  searchMemories,
+  readIndex,
+  truncateEntrypoint,
+} from "../src/memory.js"
+import { getMemoryDir, getMemoryEntrypoint, ENTRYPOINT_NAME } from "../src/paths.js"
+
+const tempDirs: string[] = []
+
+function makeTempGitRepo(): string {
+  const root = mkdtempSync(join(tmpdir(), "memory-test-"))
+  mkdirSync(join(root, ".git"), { recursive: true })
+  tempDirs.push(root)
+  return root
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop()
+    if (dir) rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe("truncateEntrypoint", () => {
+  test("returns empty result for empty string", () => {
+    const result = truncateEntrypoint("")
+    expect(result.content).toBe("")
+    expect(result.lineCount).toBe(0)
+    expect(result.byteCount).toBe(0)
+    expect(result.wasLineTruncated).toBe(false)
+    expect(result.wasByteTruncated).toBe(false)
+  })
+
+  test("returns empty result for whitespace-only string", () => {
+    const result = truncateEntrypoint("   \n\n  ")
+    expect(result.content).toBe("")
+    expect(result.lineCount).toBe(0)
+  })
+
+  test("passes through short content unchanged", () => {
+    const content = "- [Memory One](one.md) — first memory\n- [Memory Two](two.md) — second memory"
+    const result = truncateEntrypoint(content)
+    expect(result.content).toBe(content)
+    expect(result.wasLineTruncated).toBe(false)
+    expect(result.wasByteTruncated).toBe(false)
+    expect(result.lineCount).toBe(2)
+  })
+
+  test("truncates content exceeding MAX_ENTRYPOINT_LINES", () => {
+    const lines = Array.from({ length: 300 }, (_, i) => `- [Memory ${i}](m${i}.md) — description ${i}`)
+    const content = lines.join("\n")
+    const result = truncateEntrypoint(content)
+
+    expect(result.wasLineTruncated).toBe(true)
+    expect(result.lineCount).toBe(300)
+    expect(result.content).toContain("WARNING")
+    expect(result.content).toContain(ENTRYPOINT_NAME)
+    // Truncated content should have at most 200 lines + warning
+    const outputLines = result.content.split("\n")
+    const warningIdx = outputLines.findIndex((l) => l.includes("WARNING"))
+    expect(warningIdx).toBeGreaterThan(0)
+  })
+
+  test("truncates content exceeding MAX_ENTRYPOINT_BYTES", () => {
+    // Create content with few lines but huge byte size
+    const longLine = "x".repeat(30_000)
+    const content = longLine
+    const result = truncateEntrypoint(content)
+
+    expect(result.wasByteTruncated).toBe(true)
+    expect(result.content).toContain("WARNING")
+    expect(result.content).toContain("index entries are too long")
+  })
+
+  test("warning mentions both lines and bytes when both exceed", () => {
+    const lines = Array.from({ length: 300 }, (_, i) => "x".repeat(200) + ` line ${i}`)
+    const content = lines.join("\n")
+    const result = truncateEntrypoint(content)
+
+    expect(result.wasLineTruncated).toBe(true)
+    expect(result.wasByteTruncated).toBe(true)
+    expect(result.content).toContain("lines and")
+  })
+})
+
+describe("saveMemory and readMemory", () => {
+  test("saves and reads a memory file", () => {
+    const repo = makeTempGitRepo()
+    const filePath = saveMemory(repo, "test_save", "Test Save", "A test memory", "user", "Hello world")
+
+    expect(existsSync(filePath)).toBe(true)
+
+    const entry = readMemory(repo, "test_save")
+    expect(entry).not.toBeNull()
+    expect(entry!.name).toBe("Test Save")
+    expect(entry!.description).toBe("A test memory")
+    expect(entry!.type).toBe("user")
+    expect(entry!.content).toBe("Hello world")
+  })
+
+  test("appends .md to filename if missing", () => {
+    const repo = makeTempGitRepo()
+    saveMemory(repo, "no_ext", "No Extension", "Test", "feedback", "Content")
+
+    const entry = readMemory(repo, "no_ext")
+    expect(entry).not.toBeNull()
+    expect(entry!.name).toBe("No Extension")
+  })
+
+  test("handles .md extension in filename", () => {
+    const repo = makeTempGitRepo()
+    saveMemory(repo, "with_ext.md", "With Extension", "Test", "project", "Content")
+
+    const entry = readMemory(repo, "with_ext")
+    expect(entry).not.toBeNull()
+    expect(entry!.name).toBe("With Extension")
+  })
+
+  test("updates MEMORY.md index on save", () => {
+    const repo = makeTempGitRepo()
+    saveMemory(repo, "indexed", "Indexed Memory", "Should appear in index", "user", "Content")
+
+    const index = readIndex(repo)
+    expect(index).toContain("indexed.md")
+    expect(index).toContain("Indexed Memory")
+  })
+
+  test("rejects oversized memory content", () => {
+    const repo = makeTempGitRepo()
+    const bigContent = "x".repeat(50_000)
+
+    expect(() => saveMemory(repo, "big", "Big", "Too big", "user", bigContent)).toThrow("limit")
+  })
+
+  test("returns null for non-existent memory", () => {
+    const repo = makeTempGitRepo()
+    const entry = readMemory(repo, "does_not_exist")
+    expect(entry).toBeNull()
+  })
+})
+
+describe("deleteMemory", () => {
+  test("deletes existing memory and removes from index", () => {
+    const repo = makeTempGitRepo()
+    saveMemory(repo, "to_delete", "Delete Me", "Will be deleted", "user", "Gone")
+
+    const deleted = deleteMemory(repo, "to_delete")
+    expect(deleted).toBe(true)
+
+    const entry = readMemory(repo, "to_delete")
+    expect(entry).toBeNull()
+
+    const index = readIndex(repo)
+    expect(index).not.toContain("to_delete.md")
+  })
+
+  test("returns false for non-existent memory", () => {
+    const repo = makeTempGitRepo()
+    const deleted = deleteMemory(repo, "never_existed")
+    expect(deleted).toBe(false)
+  })
+})
+
+describe("listMemories", () => {
+  test("returns empty array for repo with no memories", () => {
+    const repo = makeTempGitRepo()
+    const entries = listMemories(repo)
+    expect(entries).toEqual([])
+  })
+
+  test("lists saved memories", () => {
+    const repo = makeTempGitRepo()
+    saveMemory(repo, "alpha", "Alpha", "First", "user", "Alpha content")
+    saveMemory(repo, "beta", "Beta", "Second", "feedback", "Beta content")
+
+    const entries = listMemories(repo)
+    expect(entries).toHaveLength(2)
+    const names = entries.map((e) => e.name).sort()
+    expect(names).toEqual(["Alpha", "Beta"])
+  })
+
+  test("skips MEMORY.md in listing", () => {
+    const repo = makeTempGitRepo()
+    saveMemory(repo, "real", "Real", "A real memory", "user", "Content")
+
+    const entries = listMemories(repo)
+    const fileNames = entries.map((e) => e.fileName)
+    expect(fileNames).not.toContain("MEMORY.md")
+  })
+})
+
+describe("searchMemories", () => {
+  test("returns empty for no matches", () => {
+    const repo = makeTempGitRepo()
+    saveMemory(repo, "unrelated", "Unrelated", "Nothing here", "user", "Totally different")
+
+    const results = searchMemories(repo, "zzzznonexistent")
+    expect(results).toHaveLength(0)
+  })
+
+  test("finds memories by name", () => {
+    const repo = makeTempGitRepo()
+    saveMemory(repo, "auth_setup", "Auth Setup", "Authentication config", "project", "JWT tokens")
+
+    const results = searchMemories(repo, "Auth")
+    expect(results).toHaveLength(1)
+    expect(results[0]!.name).toBe("Auth Setup")
+  })
+
+  test("finds memories by content", () => {
+    const repo = makeTempGitRepo()
+    saveMemory(repo, "style", "Code Style", "Formatting preferences", "feedback", "Always use semicolons")
+
+    const results = searchMemories(repo, "semicolons")
+    expect(results).toHaveLength(1)
+    expect(results[0]!.name).toBe("Code Style")
+  })
+
+  test("search is case-insensitive", () => {
+    const repo = makeTempGitRepo()
+    saveMemory(repo, "case_test", "Case Test", "Testing case sensitivity", "user", "UPPERCASE content")
+
+    const results = searchMemories(repo, "uppercase")
+    expect(results).toHaveLength(1)
+  })
+})
+
+describe("readIndex", () => {
+  test("returns empty string when no index exists", () => {
+    const repo = makeTempGitRepo()
+    const index = readIndex(repo)
+    expect(index).toBe("")
+  })
+
+  test("returns index content after saves", () => {
+    const repo = makeTempGitRepo()
+    saveMemory(repo, "first", "First", "Desc 1", "user", "Content 1")
+    saveMemory(repo, "second", "Second", "Desc 2", "feedback", "Content 2")
+
+    const index = readIndex(repo)
+    expect(index).toContain("first.md")
+    expect(index).toContain("second.md")
+    expect(index).toContain("First")
+    expect(index).toContain("Second")
+  })
+
+  test("updates existing entry in index on re-save", () => {
+    const repo = makeTempGitRepo()
+    saveMemory(repo, "evolving", "Version 1", "Original desc", "user", "Original")
+    saveMemory(repo, "evolving", "Version 2", "Updated desc", "user", "Updated")
+
+    const index = readIndex(repo)
+    expect(index).toContain("Version 2")
+    expect(index).not.toContain("Version 1")
+    // Should only have one entry for evolving.md
+    const matches = index.match(/evolving\.md/g)
+    expect(matches).toHaveLength(1)
+  })
+})

--- a/test/memory.test.ts
+++ b/test/memory.test.ts
@@ -195,6 +195,23 @@ describe("listMemories", () => {
     const fileNames = entries.map((e) => e.fileName)
     expect(fileNames).not.toContain("MEMORY.md")
   })
+
+  test("keeps public listing flat and hides nested memory files", () => {
+    const repo = makeTempGitRepo()
+    const memDir = getMemoryDir(repo)
+
+    saveMemory(repo, "top_level", "Top Level", "Visible memory", "user", "Visible content")
+    mkdirSync(join(memDir, "nested"), { recursive: true })
+    writeFileSync(
+      join(memDir, "nested", "child.md"),
+      "---\nname: Nested Child\ndescription: Hidden from flat API\ntype: user\n---\n\nNested content\n",
+      "utf-8",
+    )
+
+    const entries = listMemories(repo)
+    expect(entries).toHaveLength(1)
+    expect(entries[0]!.fileName).toBe("top_level.md")
+  })
 })
 
 describe("searchMemories", () => {

--- a/test/memoryScan.test.ts
+++ b/test/memoryScan.test.ts
@@ -71,6 +71,7 @@ describe("scanMemoryFiles", () => {
 
     const result = scanMemoryFiles(dir)
     expect(result).toHaveLength(1)
+    expect(result[0]!.name).toBe("Code Style")
     expect(result[0]!.description).toBe("User prefers terse responses")
     expect(result[0]!.type).toBe("feedback")
   })
@@ -197,6 +198,7 @@ describe("formatMemoryManifest", () => {
         filename: "user_role.md",
         filePath: "/tmp/memory/user_role.md",
         mtimeMs: new Date("2025-03-15T10:00:00Z").getTime(),
+        name: "User Role",
         description: "User is a senior engineer",
         type: "user",
       },
@@ -214,6 +216,7 @@ describe("formatMemoryManifest", () => {
         filename: "misc.md",
         filePath: "/tmp/memory/misc.md",
         mtimeMs: Date.now(),
+        name: null,
         description: "Some note",
         type: undefined,
       },
@@ -230,6 +233,7 @@ describe("formatMemoryManifest", () => {
         filename: "bare.md",
         filePath: "/tmp/memory/bare.md",
         mtimeMs: Date.now(),
+        name: null,
         description: null,
         type: "feedback",
       },
@@ -246,6 +250,7 @@ describe("formatMemoryManifest", () => {
         filename: "a.md",
         filePath: "/tmp/a.md",
         mtimeMs: Date.now(),
+        name: null,
         description: "First",
         type: "user",
       },
@@ -253,6 +258,7 @@ describe("formatMemoryManifest", () => {
         filename: "b.md",
         filePath: "/tmp/b.md",
         mtimeMs: Date.now(),
+        name: null,
         description: "Second",
         type: "project",
       },

--- a/test/memoryScan.test.ts
+++ b/test/memoryScan.test.ts
@@ -1,0 +1,266 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, utimesSync } from "fs"
+import { tmpdir } from "os"
+import { join } from "path"
+import { scanMemoryFiles, formatMemoryManifest } from "../src/memoryScan.js"
+
+const tempDirs: string[] = []
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "memscan-test-"))
+  tempDirs.push(dir)
+  return dir
+}
+
+function writeMemory(
+  dir: string,
+  filename: string,
+  content: string,
+  mtime?: Date,
+): string {
+  const filePath = join(dir, filename)
+  const parentDir = join(filePath, "..")
+  mkdirSync(parentDir, { recursive: true })
+  writeFileSync(filePath, content, "utf-8")
+  if (mtime) {
+    utimesSync(filePath, mtime, mtime)
+  }
+  return filePath
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop()
+    if (dir) rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe("scanMemoryFiles", () => {
+  test("returns empty array for empty directory", () => {
+    const dir = makeTempDir()
+    const result = scanMemoryFiles(dir)
+    expect(result).toEqual([])
+  })
+
+  test("returns empty array for non-existent directory", () => {
+    const result = scanMemoryFiles("/nonexistent/path/memory")
+    expect(result).toEqual([])
+  })
+
+  test("skips MEMORY.md entrypoint file", () => {
+    const dir = makeTempDir()
+    writeMemory(dir, "MEMORY.md", "# Index\n- [Test](test.md) — test")
+    writeMemory(
+      dir,
+      "test.md",
+      "---\nname: Test\ndescription: A test memory\ntype: user\n---\n\nContent here",
+    )
+
+    const result = scanMemoryFiles(dir)
+    expect(result).toHaveLength(1)
+    expect(result[0]!.filename).toBe("test.md")
+  })
+
+  test("parses frontmatter correctly", () => {
+    const dir = makeTempDir()
+    writeMemory(
+      dir,
+      "feedback_style.md",
+      "---\nname: Code Style\ndescription: User prefers terse responses\ntype: feedback\n---\n\nKeep it short.",
+    )
+
+    const result = scanMemoryFiles(dir)
+    expect(result).toHaveLength(1)
+    expect(result[0]!.description).toBe("User prefers terse responses")
+    expect(result[0]!.type).toBe("feedback")
+  })
+
+  test("handles files without frontmatter", () => {
+    const dir = makeTempDir()
+    writeMemory(dir, "no_front.md", "Just plain content, no frontmatter")
+
+    const result = scanMemoryFiles(dir)
+    expect(result).toHaveLength(1)
+    expect(result[0]!.description).toBeNull()
+    expect(result[0]!.type).toBeUndefined()
+  })
+
+  test("handles files with incomplete frontmatter", () => {
+    const dir = makeTempDir()
+    writeMemory(
+      dir,
+      "partial.md",
+      "---\nname: Partial\ndescription: Has desc but no type\n---\n\nContent",
+    )
+
+    const result = scanMemoryFiles(dir)
+    expect(result).toHaveLength(1)
+    expect(result[0]!.description).toBe("Has desc but no type")
+    expect(result[0]!.type).toBeUndefined()
+  })
+
+  test("handles files with invalid type", () => {
+    const dir = makeTempDir()
+    writeMemory(
+      dir,
+      "badtype.md",
+      "---\nname: Bad\ndescription: Invalid type\ntype: banana\n---\n\nContent",
+    )
+
+    const result = scanMemoryFiles(dir)
+    expect(result).toHaveLength(1)
+    expect(result[0]!.type).toBeUndefined()
+  })
+
+  test("sorts by mtime descending", () => {
+    const dir = makeTempDir()
+    const older = new Date("2024-01-01T00:00:00Z")
+    const newer = new Date("2025-01-01T00:00:00Z")
+
+    writeMemory(
+      dir,
+      "old.md",
+      "---\nname: Old\ndescription: Old one\ntype: user\n---\n\nOld",
+      older,
+    )
+    writeMemory(
+      dir,
+      "new.md",
+      "---\nname: New\ndescription: New one\ntype: user\n---\n\nNew",
+      newer,
+    )
+
+    const result = scanMemoryFiles(dir)
+    expect(result).toHaveLength(2)
+    expect(result[0]!.filename).toBe("new.md")
+    expect(result[1]!.filename).toBe("old.md")
+  })
+
+  test("scans subdirectories recursively", () => {
+    const dir = makeTempDir()
+    writeMemory(
+      dir,
+      "top.md",
+      "---\nname: Top\ndescription: Top level\ntype: user\n---\n\nTop",
+    )
+    writeMemory(
+      dir,
+      "sub/nested.md",
+      "---\nname: Nested\ndescription: In subdirectory\ntype: project\n---\n\nNested",
+    )
+
+    const result = scanMemoryFiles(dir)
+    expect(result).toHaveLength(2)
+    const filenames = result.map((h) => h.filename).sort()
+    expect(filenames).toContain("top.md")
+    expect(filenames).toContain("sub/nested.md")
+  })
+
+  test("skips non-.md files", () => {
+    const dir = makeTempDir()
+    writeFileSync(join(dir, "readme.txt"), "not a memory")
+    writeFileSync(join(dir, "data.json"), '{"not":"memory"}')
+    writeMemory(
+      dir,
+      "real.md",
+      "---\nname: Real\ndescription: Real memory\ntype: user\n---\n\nReal",
+    )
+
+    const result = scanMemoryFiles(dir)
+    expect(result).toHaveLength(1)
+    expect(result[0]!.filename).toBe("real.md")
+  })
+
+  test("handles frontmatter with unclosed delimiter", () => {
+    const dir = makeTempDir()
+    writeMemory(
+      dir,
+      "unclosed.md",
+      "---\nname: Unclosed\ndescription: No closing delimiter\ntype: user\nsome content here",
+    )
+
+    const result = scanMemoryFiles(dir)
+    expect(result).toHaveLength(1)
+    // No closing --- → frontmatter parsing fails gracefully
+    expect(result[0]!.description).toBeNull()
+  })
+})
+
+describe("formatMemoryManifest", () => {
+  test("returns empty string for empty array", () => {
+    expect(formatMemoryManifest([])).toBe("")
+  })
+
+  test("formats single memory with type and description", () => {
+    const result = formatMemoryManifest([
+      {
+        filename: "user_role.md",
+        filePath: "/tmp/memory/user_role.md",
+        mtimeMs: new Date("2025-03-15T10:00:00Z").getTime(),
+        description: "User is a senior engineer",
+        type: "user",
+      },
+    ])
+
+    expect(result).toContain("[user]")
+    expect(result).toContain("user_role.md")
+    expect(result).toContain("User is a senior engineer")
+    expect(result).toContain("2025-03-15")
+  })
+
+  test("formats memory without type", () => {
+    const result = formatMemoryManifest([
+      {
+        filename: "misc.md",
+        filePath: "/tmp/memory/misc.md",
+        mtimeMs: Date.now(),
+        description: "Some note",
+        type: undefined,
+      },
+    ])
+
+    expect(result).not.toContain("[")
+    expect(result).toContain("misc.md")
+    expect(result).toContain("Some note")
+  })
+
+  test("formats memory without description", () => {
+    const result = formatMemoryManifest([
+      {
+        filename: "bare.md",
+        filePath: "/tmp/memory/bare.md",
+        mtimeMs: Date.now(),
+        description: null,
+        type: "feedback",
+      },
+    ])
+
+    expect(result).toContain("[feedback]")
+    expect(result).toContain("bare.md")
+    expect(result).not.toContain(": null")
+  })
+
+  test("formats multiple memories as separate lines", () => {
+    const result = formatMemoryManifest([
+      {
+        filename: "a.md",
+        filePath: "/tmp/a.md",
+        mtimeMs: Date.now(),
+        description: "First",
+        type: "user",
+      },
+      {
+        filename: "b.md",
+        filePath: "/tmp/b.md",
+        mtimeMs: Date.now(),
+        description: "Second",
+        type: "project",
+      },
+    ])
+
+    const lines = result.split("\n")
+    expect(lines).toHaveLength(2)
+    expect(lines[0]).toContain("First")
+    expect(lines[1]).toContain("Second")
+  })
+})

--- a/test/opencode-memory.test.ts
+++ b/test/opencode-memory.test.ts
@@ -441,6 +441,73 @@ exit 0
     expect(logContent).toContain("fork session:ses_storage_target")
   })
 
+  test("parses large export payloads without exceeding argv limits", () => {
+    const root = makeTempRoot()
+    const fakeBin = join(root, "bin")
+    const homeDir = join(root, "home")
+    const tmpDir = join(root, "tmp")
+    const claudeDir = join(root, "claude")
+
+    mkdirSync(fakeBin, { recursive: true })
+    mkdirSync(homeDir, { recursive: true })
+    mkdirSync(tmpDir, { recursive: true })
+    mkdirSync(claudeDir, { recursive: true })
+
+    writeExecutable(
+      join(fakeBin, "opencode"),
+      `#!/usr/bin/env bash
+set -euo pipefail
+if [ "\${1:-}" = "session" ] && [ "\${2:-}" = "list" ]; then
+  echo '[]'
+  exit 0
+fi
+if [ "\${1:-}" = "export" ]; then
+  python3 - <<'PY'
+import json
+print(json.dumps({"info": {"directory": "${root}"}, "padding": "x" * 400000}))
+PY
+  exit 0
+fi
+if [ "\${1:-}" = "run" ] && [ "\${2:-}" != "-s" ]; then
+  mkdir -p "$HOME/.local/share/opencode/storage/session_diff"
+  printf '{"files":[]}\n' > "$HOME/.local/share/opencode/storage/session_diff/ses_large_export.json"
+  echo "main run ok"
+  exit 0
+fi
+if [ "\${1:-}" = "run" ] && [ "\${2:-}" = "-s" ]; then
+  echo "fork session:\${3:-}"
+  exit 0
+fi
+exit 0
+`,
+    )
+
+    const result = spawnSync("bash", [scriptPath, "run", "hello"], {
+      cwd: root,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+        HOME: homeDir,
+        TMPDIR: tmpDir,
+        CLAUDE_CONFIG_DIR: claudeDir,
+        OPENCODE_MEMORY_SESSION_WAIT_SECONDS: "1",
+        OPENCODE_MEMORY_FOREGROUND: "1",
+        OPENCODE_MEMORY_AUTODREAM: "0",
+      },
+    })
+
+    expect(result.status).toBe(0)
+
+    const logDir = join(root, "tmp", "opencode-memory-logs")
+    const logFiles = readdirSync(logDir)
+    expect(logFiles).toHaveLength(1)
+
+    const logPath = join(logDir, logFiles[0] ?? "")
+    const logContent = readFileSync(logPath, "utf-8")
+    expect(logContent).toContain("fork session:ses_large_export")
+  })
+
   test("prefers in-scope session list result over newer out-of-scope artifacts", () => {
     const root = makeTempRoot()
     const fakeBin = join(root, "bin")

--- a/test/opencode-memory.test.ts
+++ b/test/opencode-memory.test.ts
@@ -45,7 +45,7 @@ describe("opencode-memory wrapper", () => {
       `#!/usr/bin/env bash
 set -euo pipefail
 if [ "\${1:-}" = "session" ] && [ "\${2:-}" = "list" ]; then
-  echo '[{"id":"ses_test_123","time":{"updated":1,"created":1}}]'
+  echo '[{"id":"ses_test_123","directory":"${root}","time":{"updated":1,"created":1}}]'
   exit 0
 fi
 if [ "\${1:-}" = "run" ]; then
@@ -69,6 +69,7 @@ exit 0
         HOME: homeDir,
         TMPDIR: tmpDir,
         CLAUDE_CONFIG_DIR: claudeDir,
+        OPENCODE_MEMORY_SESSION_WAIT_SECONDS: "1",
         OPENCODE_MEMORY_FOREGROUND: "1",
         OPENCODE_MEMORY_AUTODREAM: "0",
       },
@@ -104,7 +105,7 @@ exit 0
       `#!/usr/bin/env bash
 set -euo pipefail
 if [ "\${1:-}" = "session" ] && [ "\${2:-}" = "list" ]; then
-  echo '[{"id":"ses_test_456","time":{"updated":1,"created":1}}]'
+  echo '[{"id":"ses_test_456","directory":"${root}","time":{"updated":1,"created":1}}]'
   exit 0
 fi
 if [ "\${1:-}" = "run" ]; then
@@ -197,7 +198,7 @@ if [ "\${1:-}" = "session" ] && [ "\${2:-}" = "list" ]; then
   if [ ! -f "$STATE_FILE" ]; then
     echo '[{"id":"ses_other_newest","updated":10,"created":10},{"id":"ses_existing_old","updated":1,"created":1}]'
   else
-    echo '[{"id":"ses_other_newest","updated":30,"created":30},{"id":"ses_wrapped_target","updated":20,"created":20},{"id":"ses_existing_old","updated":1,"created":1}]'
+    echo '[{"id":"ses_other_newest","updated":30,"created":30},{"id":"ses_wrapped_target","directory":"${root}","updated":20,"created":20},{"id":"ses_existing_old","updated":1,"created":1}]'
   fi
   exit 0
 fi
@@ -223,6 +224,7 @@ exit 0
         HOME: homeDir,
         TMPDIR: tmpDir,
         CLAUDE_CONFIG_DIR: claudeDir,
+        OPENCODE_MEMORY_SESSION_WAIT_SECONDS: "1",
         OPENCODE_MEMORY_FOREGROUND: "1",
         OPENCODE_MEMORY_AUTODREAM: "0",
       },
@@ -260,6 +262,12 @@ if [ "\${1:-}" = "session" ] && [ "\${2:-}" = "list" ]; then
   echo '[{"id":"ses_other_newest","updated":30,"created":30}]'
   exit 0
 fi
+if [ "\${1:-}" = "export" ]; then
+  cat <<'JSON'
+{"info":{"directory":"${root}"}}
+JSON
+  exit 0
+fi
 if [ "\${1:-}" = "run" ] && [ "\${2:-}" != "-s" ]; then
   mkdir -p "$CLAUDE_CONFIG_DIR/transcripts"
   printf '{"type":"user","content":"wrapped"}\n' > "$CLAUDE_CONFIG_DIR/transcripts/ses_wrapped_target.jsonl"
@@ -283,6 +291,7 @@ exit 0
         HOME: homeDir,
         TMPDIR: tmpDir,
         CLAUDE_CONFIG_DIR: claudeDir,
+        OPENCODE_MEMORY_SESSION_WAIT_SECONDS: "1",
         OPENCODE_MEMORY_FOREGROUND: "1",
         OPENCODE_MEMORY_AUTODREAM: "0",
       },
@@ -320,6 +329,12 @@ if [ "\${1:-}" = "session" ] && [ "\${2:-}" = "list" ]; then
   echo '[]'
   exit 0
 fi
+if [ "\${1:-}" = "export" ]; then
+  cat <<'JSON'
+{"info":{"directory":"${root}"}}
+JSON
+  exit 0
+fi
 if [ "\${1:-}" = "run" ] && [ "\${2:-}" != "-s" ]; then
   mkdir -p "$CLAUDE_CONFIG_DIR/transcripts"
   (sleep 1; printf '{"type":"user","content":"wrapped"}\n' > "$CLAUDE_CONFIG_DIR/transcripts/ses_delayed_target.jsonl") &
@@ -343,6 +358,7 @@ exit 0
         HOME: homeDir,
         TMPDIR: tmpDir,
         CLAUDE_CONFIG_DIR: claudeDir,
+        OPENCODE_MEMORY_SESSION_WAIT_SECONDS: "2",
         OPENCODE_MEMORY_FOREGROUND: "1",
         OPENCODE_MEMORY_AUTODREAM: "0",
       },
@@ -379,6 +395,12 @@ if [ "\${1:-}" = "session" ] && [ "\${2:-}" = "list" ]; then
   echo '[]'
   exit 0
 fi
+if [ "\${1:-}" = "export" ]; then
+  cat <<'JSON'
+{"info":{"directory":"${root}"}}
+JSON
+  exit 0
+fi
 if [ "\${1:-}" = "run" ] && [ "\${2:-}" != "-s" ]; then
   mkdir -p "$HOME/.local/share/opencode/storage/session_diff"
   printf '{"files":[]}\n' > "$HOME/.local/share/opencode/storage/session_diff/ses_storage_target.json"
@@ -402,6 +424,7 @@ exit 0
         HOME: homeDir,
         TMPDIR: tmpDir,
         CLAUDE_CONFIG_DIR: claudeDir,
+        OPENCODE_MEMORY_SESSION_WAIT_SECONDS: "1",
         OPENCODE_MEMORY_FOREGROUND: "1",
         OPENCODE_MEMORY_AUTODREAM: "0",
       },
@@ -416,6 +439,81 @@ exit 0
     const logPath = join(logDir, logFiles[0] ?? "")
     const logContent = readFileSync(logPath, "utf-8")
     expect(logContent).toContain("fork session:ses_storage_target")
+  })
+
+  test("prefers in-scope session list result over newer out-of-scope artifacts", () => {
+    const root = makeTempRoot()
+    const fakeBin = join(root, "bin")
+    const homeDir = join(root, "home")
+    const tmpDir = join(root, "tmp")
+    const claudeDir = join(root, "claude")
+
+    mkdirSync(fakeBin, { recursive: true })
+    mkdirSync(homeDir, { recursive: true })
+    mkdirSync(tmpDir, { recursive: true })
+    mkdirSync(claudeDir, { recursive: true })
+
+    writeExecutable(
+      join(fakeBin, "opencode"),
+      `#!/usr/bin/env bash
+set -euo pipefail
+if [ "\${1:-}" = "session" ] && [ "\${2:-}" = "list" ]; then
+  echo '[{"id":"ses_wrapped_target","updated":10,"created":10,"directory":"${root}"}]'
+  exit 0
+fi
+if [ "\${1:-}" = "export" ]; then
+  if [ "\${2:-}" = "ses_other_repo" ]; then
+    cat <<'JSON'
+{"info":{"directory":"${root}/other-repo"}}
+JSON
+  else
+    cat <<'JSON'
+{"info":{"directory":"${root}"}}
+JSON
+  fi
+  exit 0
+fi
+if [ "\${1:-}" = "run" ] && [ "\${2:-}" != "-s" ]; then
+  mkdir -p "$CLAUDE_CONFIG_DIR/transcripts" "$HOME/.local/share/opencode/storage/session_diff"
+  printf '{"type":"user","content":"wrapped"}\n' > "$CLAUDE_CONFIG_DIR/transcripts/ses_wrapped_target.jsonl"
+  sleep 1
+  printf '{"type":"user","content":"other"}\n' > "$CLAUDE_CONFIG_DIR/transcripts/ses_other_repo.jsonl"
+  echo "main run ok"
+  exit 0
+fi
+if [ "\${1:-}" = "run" ] && [ "\${2:-}" = "-s" ]; then
+  echo "fork session:\${3:-}"
+  exit 0
+fi
+exit 0
+`,
+    )
+
+    const result = spawnSync("bash", [scriptPath, "run", "hello"], {
+      cwd: root,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+        HOME: homeDir,
+        TMPDIR: tmpDir,
+        CLAUDE_CONFIG_DIR: claudeDir,
+        OPENCODE_MEMORY_SESSION_WAIT_SECONDS: "1",
+        OPENCODE_MEMORY_FOREGROUND: "1",
+        OPENCODE_MEMORY_AUTODREAM: "0",
+      },
+    })
+
+    expect(result.status).toBe(0)
+
+    const logDir = join(root, "tmp", "opencode-memory-logs")
+    const logFiles = readdirSync(logDir)
+    expect(logFiles).toHaveLength(1)
+
+    const logPath = join(logDir, logFiles[0] ?? "")
+    const logContent = readFileSync(logPath, "utf-8")
+    expect(logContent).toContain("fork session:ses_wrapped_target")
+    expect(logContent).not.toContain("fork session:ses_other_repo")
   })
 
   test("sets OPENCODE_MEMORY_IGNORE for wrapped run prompts that explicitly ignore memory", () => {
@@ -458,6 +556,7 @@ exit 0
           HOME: homeDir,
           TMPDIR: tmpDir,
           CLAUDE_CONFIG_DIR: claudeDir,
+          OPENCODE_MEMORY_SESSION_WAIT_SECONDS: "1",
           OPENCODE_MEMORY_EXTRACT: "0",
           OPENCODE_MEMORY_AUTODREAM: "0",
         },
@@ -487,7 +586,7 @@ exit 0
       `#!/usr/bin/env bash
 set -euo pipefail
 if [ "\${1:-}" = "session" ] && [ "\${2:-}" = "list" ]; then
-  echo '[{"id":"ses_wrapped_target","updated":10,"created":10}]'
+  echo '[{"id":"ses_wrapped_target","updated":10,"created":10,"directory":"${wrappedDir}"}]'
   exit 0
 fi
 if [ "\${1:-}" = "run" ] && [ "\${2:-}" != "-s" ]; then
@@ -513,6 +612,7 @@ exit 0
         HOME: homeDir,
         TMPDIR: tmpDir,
         CLAUDE_CONFIG_DIR: claudeDir,
+        OPENCODE_MEMORY_SESSION_WAIT_SECONDS: "1",
         OPENCODE_MEMORY_FOREGROUND: "1",
         OPENCODE_MEMORY_AUTODREAM: "0",
       },
@@ -527,5 +627,67 @@ exit 0
     const logPath = join(logDir, logFiles[0] ?? "")
     const logContent = readFileSync(logPath, "utf-8")
     expect(logContent).toContain(`fork args:run -s ses_wrapped_target --fork --dir ${wrappedDir}`)
+  })
+
+  test("uses positional project path as wrapped working directory", () => {
+    const root = makeTempRoot()
+    const fakeBin = join(root, "bin")
+    const homeDir = join(root, "home")
+    const tmpDir = join(root, "tmp")
+    const claudeDir = join(root, "claude")
+    const projectDir = join(root, "project-repo")
+
+    mkdirSync(fakeBin, { recursive: true })
+    mkdirSync(homeDir, { recursive: true })
+    mkdirSync(tmpDir, { recursive: true })
+    mkdirSync(claudeDir, { recursive: true })
+    mkdirSync(projectDir, { recursive: true })
+
+    writeExecutable(
+      join(fakeBin, "opencode"),
+      `#!/usr/bin/env bash
+set -euo pipefail
+if [ "\${1:-}" = "session" ] && [ "\${2:-}" = "list" ]; then
+  echo '[{"id":"ses_wrapped_target","updated":10,"created":10,"directory":"${projectDir}"}]'
+  exit 0
+fi
+if [ "\${1:-}" = "run" ] && [ "\${2:-}" != "-s" ]; then
+  mkdir -p "$CLAUDE_CONFIG_DIR/transcripts"
+  printf '{"type":"user","content":"wrapped"}\n' > "$CLAUDE_CONFIG_DIR/transcripts/ses_wrapped_target.jsonl"
+  echo "main run ok"
+  exit 0
+fi
+if [ "\${1:-}" = "run" ] && [ "\${2:-}" = "-s" ]; then
+  printf 'fork args:%s\n' "$*"
+  exit 0
+fi
+exit 0
+`,
+    )
+
+    const result = spawnSync("bash", [scriptPath, projectDir], {
+      cwd: root,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+        HOME: homeDir,
+        TMPDIR: tmpDir,
+        CLAUDE_CONFIG_DIR: claudeDir,
+        OPENCODE_MEMORY_SESSION_WAIT_SECONDS: "1",
+        OPENCODE_MEMORY_FOREGROUND: "1",
+        OPENCODE_MEMORY_AUTODREAM: "0",
+      },
+    })
+
+    expect(result.status).toBe(0)
+
+    const logDir = join(root, "tmp", "opencode-memory-logs")
+    const logFiles = readdirSync(logDir)
+    expect(logFiles).toHaveLength(1)
+
+    const logPath = join(logDir, logFiles[0] ?? "")
+    const logContent = readFileSync(logPath, "utf-8")
+    expect(logContent).toContain(`fork args:run -s ses_wrapped_target --fork --dir ${projectDir}`)
   })
 })

--- a/test/opencode-memory.test.ts
+++ b/test/opencode-memory.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { chmodSync, existsSync, mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "fs"
+import { chmodSync, existsSync, mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, symlinkSync, writeFileSync } from "fs"
 import { tmpdir } from "os"
 import { join } from "path"
 import { spawnSync } from "child_process"
@@ -143,5 +143,389 @@ exit 0
 
     const logPath = join(logDir, logFiles[0] ?? "")
     expect(readFileSync(logPath, "utf-8")).toContain("extraction ok")
+  })
+
+  test("prints version correctly from a global-style symlinked install layout", () => {
+    const root = makeTempRoot()
+    const fakePrefix = join(root, "prefix")
+    const fakeBin = join(fakePrefix, "bin")
+    const packageRoot = join(fakePrefix, "lib", "node_modules", "opencode-claude-memory")
+    const packageBin = join(packageRoot, "bin")
+
+    mkdirSync(fakeBin, { recursive: true })
+    mkdirSync(packageBin, { recursive: true })
+
+    writeFileSync(
+      join(packageRoot, "package.json"),
+      '{\n  "name": "opencode-claude-memory",\n  "version": "9.9.9-test"\n}',
+      "utf-8",
+    )
+    writeFileSync(join(packageBin, "opencode-memory"), readFileSync(scriptPath, "utf-8"), "utf-8")
+    chmodSync(join(packageBin, "opencode-memory"), 0o755)
+
+    const symlinkPath = join(fakeBin, "opencode-memory")
+    symlinkSync(join(packageBin, "opencode-memory"), symlinkPath)
+
+    const result = spawnSync("bash", [symlinkPath, "self", "-v"], {
+      cwd: root,
+      encoding: "utf-8",
+    })
+
+    expect(result.status).toBe(0)
+    expect(result.stdout.trim()).toBe("9.9.9-test")
+  })
+
+  test("targets the newly created wrapped session instead of the globally latest session", () => {
+    const root = makeTempRoot()
+    const fakeBin = join(root, "bin")
+    const homeDir = join(root, "home")
+    const tmpDir = join(root, "tmp")
+    const claudeDir = join(root, "claude")
+    const stateFile = join(root, "state")
+
+    mkdirSync(fakeBin, { recursive: true })
+    mkdirSync(homeDir, { recursive: true })
+    mkdirSync(tmpDir, { recursive: true })
+    mkdirSync(claudeDir, { recursive: true })
+
+    writeExecutable(
+      join(fakeBin, "opencode"),
+      `#!/usr/bin/env bash
+set -euo pipefail
+STATE_FILE="${stateFile}"
+if [ "\${1:-}" = "session" ] && [ "\${2:-}" = "list" ]; then
+  if [ ! -f "$STATE_FILE" ]; then
+    echo '[{"id":"ses_other_newest","updated":10,"created":10},{"id":"ses_existing_old","updated":1,"created":1}]'
+  else
+    echo '[{"id":"ses_other_newest","updated":30,"created":30},{"id":"ses_wrapped_target","updated":20,"created":20},{"id":"ses_existing_old","updated":1,"created":1}]'
+  fi
+  exit 0
+fi
+if [ "\${1:-}" != "session" ] && ! { [ "\${1:-}" = "run" ] && [ "\${2:-}" = "-s" ]; }; then
+  echo wrapped > "$STATE_FILE"
+  echo "main run ok"
+  exit 0
+fi
+if [ "\${1:-}" = "run" ] && [ "\${2:-}" = "-s" ]; then
+  echo "fork session:\${3:-}" 
+  exit 0
+fi
+exit 0
+`,
+    )
+
+    const result = spawnSync("bash", [scriptPath, "--help"], {
+      cwd: root,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+        HOME: homeDir,
+        TMPDIR: tmpDir,
+        CLAUDE_CONFIG_DIR: claudeDir,
+        OPENCODE_MEMORY_FOREGROUND: "1",
+        OPENCODE_MEMORY_AUTODREAM: "0",
+      },
+    })
+
+    expect(result.status).toBe(0)
+
+    const logDir = join(root, "tmp", "opencode-memory-logs")
+    const logFiles = readdirSync(logDir)
+    expect(logFiles).toHaveLength(1)
+
+    const logPath = join(logDir, logFiles[0] ?? "")
+    const logContent = readFileSync(logPath, "utf-8")
+    expect(logContent).toContain("fork session:ses_wrapped_target")
+    expect(logContent).not.toContain("fork session:ses_other_newest")
+  })
+
+  test("prefers transcript-discovered session when session list misses the wrapped repo session", () => {
+    const root = makeTempRoot()
+    const fakeBin = join(root, "bin")
+    const homeDir = join(root, "home")
+    const tmpDir = join(root, "tmp")
+    const claudeDir = join(root, "claude")
+
+    mkdirSync(fakeBin, { recursive: true })
+    mkdirSync(homeDir, { recursive: true })
+    mkdirSync(tmpDir, { recursive: true })
+    mkdirSync(claudeDir, { recursive: true })
+
+    writeExecutable(
+      join(fakeBin, "opencode"),
+      `#!/usr/bin/env bash
+set -euo pipefail
+if [ "\${1:-}" = "session" ] && [ "\${2:-}" = "list" ]; then
+  echo '[{"id":"ses_other_newest","updated":30,"created":30}]'
+  exit 0
+fi
+if [ "\${1:-}" = "run" ] && [ "\${2:-}" != "-s" ]; then
+  mkdir -p "$CLAUDE_CONFIG_DIR/transcripts"
+  printf '{"type":"user","content":"wrapped"}\n' > "$CLAUDE_CONFIG_DIR/transcripts/ses_wrapped_target.jsonl"
+  echo "main run ok"
+  exit 0
+fi
+if [ "\${1:-}" = "run" ] && [ "\${2:-}" = "-s" ]; then
+  echo "fork session:\${3:-}"
+  exit 0
+fi
+exit 0
+`,
+    )
+
+    const result = spawnSync("bash", [scriptPath, "run", "hello"], {
+      cwd: root,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+        HOME: homeDir,
+        TMPDIR: tmpDir,
+        CLAUDE_CONFIG_DIR: claudeDir,
+        OPENCODE_MEMORY_FOREGROUND: "1",
+        OPENCODE_MEMORY_AUTODREAM: "0",
+      },
+    })
+
+    expect(result.status).toBe(0)
+
+    const logDir = join(root, "tmp", "opencode-memory-logs")
+    const logFiles = readdirSync(logDir)
+    expect(logFiles).toHaveLength(1)
+
+    const logPath = join(logDir, logFiles[0] ?? "")
+    const logContent = readFileSync(logPath, "utf-8")
+    expect(logContent).toContain("fork session:ses_wrapped_target")
+    expect(logContent).not.toContain("fork session:ses_other_newest")
+  })
+
+  test("waits briefly for delayed transcript session discovery", () => {
+    const root = makeTempRoot()
+    const fakeBin = join(root, "bin")
+    const homeDir = join(root, "home")
+    const tmpDir = join(root, "tmp")
+    const claudeDir = join(root, "claude")
+
+    mkdirSync(fakeBin, { recursive: true })
+    mkdirSync(homeDir, { recursive: true })
+    mkdirSync(tmpDir, { recursive: true })
+    mkdirSync(claudeDir, { recursive: true })
+
+    writeExecutable(
+      join(fakeBin, "opencode"),
+      `#!/usr/bin/env bash
+set -euo pipefail
+if [ "\${1:-}" = "session" ] && [ "\${2:-}" = "list" ]; then
+  echo '[]'
+  exit 0
+fi
+if [ "\${1:-}" = "run" ] && [ "\${2:-}" != "-s" ]; then
+  mkdir -p "$CLAUDE_CONFIG_DIR/transcripts"
+  (sleep 1; printf '{"type":"user","content":"wrapped"}\n' > "$CLAUDE_CONFIG_DIR/transcripts/ses_delayed_target.jsonl") &
+  echo "main run ok"
+  exit 0
+fi
+if [ "\${1:-}" = "run" ] && [ "\${2:-}" = "-s" ]; then
+  echo "fork session:\${3:-}"
+  exit 0
+fi
+exit 0
+`,
+    )
+
+    const result = spawnSync("bash", [scriptPath, "run", "hello"], {
+      cwd: root,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+        HOME: homeDir,
+        TMPDIR: tmpDir,
+        CLAUDE_CONFIG_DIR: claudeDir,
+        OPENCODE_MEMORY_FOREGROUND: "1",
+        OPENCODE_MEMORY_AUTODREAM: "0",
+      },
+    })
+
+    expect(result.status).toBe(0)
+
+    const logDir = join(root, "tmp", "opencode-memory-logs")
+    const logFiles = readdirSync(logDir)
+    expect(logFiles).toHaveLength(1)
+
+    const logPath = join(logDir, logFiles[0] ?? "")
+    const logContent = readFileSync(logPath, "utf-8")
+    expect(logContent).toContain("fork session:ses_delayed_target")
+  })
+
+  test("prefers storage session discovery when transcripts are absent", () => {
+    const root = makeTempRoot()
+    const fakeBin = join(root, "bin")
+    const homeDir = join(root, "home")
+    const tmpDir = join(root, "tmp")
+    const claudeDir = join(root, "claude")
+
+    mkdirSync(fakeBin, { recursive: true })
+    mkdirSync(homeDir, { recursive: true })
+    mkdirSync(tmpDir, { recursive: true })
+    mkdirSync(claudeDir, { recursive: true })
+
+    writeExecutable(
+      join(fakeBin, "opencode"),
+      `#!/usr/bin/env bash
+set -euo pipefail
+if [ "\${1:-}" = "session" ] && [ "\${2:-}" = "list" ]; then
+  echo '[]'
+  exit 0
+fi
+if [ "\${1:-}" = "run" ] && [ "\${2:-}" != "-s" ]; then
+  mkdir -p "$HOME/.local/share/opencode/storage/session_diff"
+  printf '{"files":[]}\n' > "$HOME/.local/share/opencode/storage/session_diff/ses_storage_target.json"
+  echo "main run ok"
+  exit 0
+fi
+if [ "\${1:-}" = "run" ] && [ "\${2:-}" = "-s" ]; then
+  echo "fork session:\${3:-}"
+  exit 0
+fi
+exit 0
+`,
+    )
+
+    const result = spawnSync("bash", [scriptPath, "run", "hello"], {
+      cwd: root,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+        HOME: homeDir,
+        TMPDIR: tmpDir,
+        CLAUDE_CONFIG_DIR: claudeDir,
+        OPENCODE_MEMORY_FOREGROUND: "1",
+        OPENCODE_MEMORY_AUTODREAM: "0",
+      },
+    })
+
+    expect(result.status).toBe(0)
+
+    const logDir = join(root, "tmp", "opencode-memory-logs")
+    const logFiles = readdirSync(logDir)
+    expect(logFiles).toHaveLength(1)
+
+    const logPath = join(logDir, logFiles[0] ?? "")
+    const logContent = readFileSync(logPath, "utf-8")
+    expect(logContent).toContain("fork session:ses_storage_target")
+  })
+
+  test("sets OPENCODE_MEMORY_IGNORE for wrapped run prompts that explicitly ignore memory", () => {
+    const root = makeTempRoot()
+    const fakeBin = join(root, "bin")
+    const homeDir = join(root, "home")
+    const tmpDir = join(root, "tmp")
+    const claudeDir = join(root, "claude")
+
+    mkdirSync(fakeBin, { recursive: true })
+    mkdirSync(homeDir, { recursive: true })
+    mkdirSync(tmpDir, { recursive: true })
+    mkdirSync(claudeDir, { recursive: true })
+
+    writeExecutable(
+      join(fakeBin, "opencode"),
+      `#!/usr/bin/env bash
+set -euo pipefail
+if [ "\${1:-}" = "session" ] && [ "\${2:-}" = "list" ]; then
+  echo '[]'
+  exit 0
+fi
+if [ "\${1:-}" = "run" ] && [ "\${2:-}" != "-s" ]; then
+  echo "ignore=\${OPENCODE_MEMORY_IGNORE:-0}"
+  exit 0
+fi
+exit 0
+`,
+    )
+
+    const result = spawnSync(
+      "bash",
+      [scriptPath, "run", "Ignore memory and answer from fresh context only."],
+      {
+        cwd: root,
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+          HOME: homeDir,
+          TMPDIR: tmpDir,
+          CLAUDE_CONFIG_DIR: claudeDir,
+          OPENCODE_MEMORY_EXTRACT: "0",
+          OPENCODE_MEMORY_AUTODREAM: "0",
+        },
+      },
+    )
+
+    expect(result.status).toBe(0)
+    expect(result.stdout).toContain("ignore=1")
+  })
+
+  test("passes the wrapped working directory to forked extraction runs", () => {
+    const root = makeTempRoot()
+    const fakeBin = join(root, "bin")
+    const homeDir = join(root, "home")
+    const tmpDir = join(root, "tmp")
+    const claudeDir = join(root, "claude")
+    const wrappedDir = join(root, "wrapped-repo")
+
+    mkdirSync(fakeBin, { recursive: true })
+    mkdirSync(homeDir, { recursive: true })
+    mkdirSync(tmpDir, { recursive: true })
+    mkdirSync(claudeDir, { recursive: true })
+    mkdirSync(wrappedDir, { recursive: true })
+
+    writeExecutable(
+      join(fakeBin, "opencode"),
+      `#!/usr/bin/env bash
+set -euo pipefail
+if [ "\${1:-}" = "session" ] && [ "\${2:-}" = "list" ]; then
+  echo '[{"id":"ses_wrapped_target","updated":10,"created":10}]'
+  exit 0
+fi
+if [ "\${1:-}" = "run" ] && [ "\${2:-}" != "-s" ]; then
+  mkdir -p "$CLAUDE_CONFIG_DIR/transcripts"
+  printf '{"type":"user","content":"wrapped"}\n' > "$CLAUDE_CONFIG_DIR/transcripts/ses_wrapped_target.jsonl"
+  echo "main run ok"
+  exit 0
+fi
+if [ "\${1:-}" = "run" ] && [ "\${2:-}" = "-s" ]; then
+  printf 'fork args:%s\n' "$*"
+  exit 0
+fi
+exit 0
+`,
+    )
+
+    const result = spawnSync("bash", [scriptPath, "run", "hello", "--dir", wrappedDir], {
+      cwd: root,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+        HOME: homeDir,
+        TMPDIR: tmpDir,
+        CLAUDE_CONFIG_DIR: claudeDir,
+        OPENCODE_MEMORY_FOREGROUND: "1",
+        OPENCODE_MEMORY_AUTODREAM: "0",
+      },
+    })
+
+    expect(result.status).toBe(0)
+
+    const logDir = join(root, "tmp", "opencode-memory-logs")
+    const logFiles = readdirSync(logDir)
+    expect(logFiles).toHaveLength(1)
+
+    const logPath = join(logDir, logFiles[0] ?? "")
+    const logContent = readFileSync(logPath, "utf-8")
+    expect(logContent).toContain(`fork args:run -s ses_wrapped_target --fork --dir ${wrappedDir}`)
   })
 })

--- a/test/prompt.test.ts
+++ b/test/prompt.test.ts
@@ -143,4 +143,16 @@ describe("buildMemorySystemPrompt", () => {
     const prompt = buildMemorySystemPrompt(repo, "")
     expect(prompt).not.toContain("## Recalled Memories")
   })
+
+  test("can suppress MEMORY.md context for ignore-memory turns", () => {
+    const repo = makeTempGitRepo()
+    const entrypoint = getMemoryEntrypoint(repo)
+    writeFileSync(entrypoint, "- [Hidden Memory](hidden.md) — Should not be injected\n", "utf-8")
+
+    const prompt = buildMemorySystemPrompt(repo, undefined, { includeIndex: false })
+
+    expect(prompt).toContain("# Auto Memory")
+    expect(prompt).not.toContain("## MEMORY.md")
+    expect(prompt).not.toContain("Hidden Memory")
+  })
 })

--- a/test/prompt.test.ts
+++ b/test/prompt.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "fs"
 import { tmpdir } from "os"
 import { join } from "path"
 import { buildMemorySystemPrompt } from "../src/prompt.js"
-import { getMemoryDir, getMemoryEntrypoint, ENTRYPOINT_NAME } from "../src/paths.js"
+import { getMemoryDir, getMemoryEntrypoint, getProjectDir, ENTRYPOINT_NAME } from "../src/paths.js"
 
 const tempDirs: string[] = []
 
@@ -154,5 +154,20 @@ describe("buildMemorySystemPrompt", () => {
     expect(prompt).toContain("# Auto Memory")
     expect(prompt).not.toContain("## MEMORY.md")
     expect(prompt).not.toContain("Hidden Memory")
+  })
+
+  test("includes Searching past context section with grep commands", () => {
+    const repo = makeTempGitRepo()
+    const memDir = getMemoryDir(repo)
+    const projectDir = getProjectDir(repo)
+    const prompt = buildMemorySystemPrompt(repo)
+
+    expect(prompt).toContain("## Searching past context")
+    expect(prompt).toContain(memDir)
+    expect(prompt).toContain(projectDir)
+    expect(prompt).toContain('grep -rn')
+    expect(prompt).toContain('--include="*.md"')
+    expect(prompt).toContain('--include="*.jsonl"')
+    expect(prompt).toContain("narrow search terms")
   })
 })

--- a/test/prompt.test.ts
+++ b/test/prompt.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "fs"
+import { tmpdir } from "os"
+import { join } from "path"
+import { buildMemorySystemPrompt } from "../src/prompt.js"
+import { getMemoryDir, getMemoryEntrypoint, ENTRYPOINT_NAME } from "../src/paths.js"
+
+const tempDirs: string[] = []
+
+function makeTempGitRepo(): string {
+  const root = mkdtempSync(join(tmpdir(), "prompt-test-"))
+  mkdirSync(join(root, ".git"), { recursive: true })
+  tempDirs.push(root)
+  return root
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop()
+    if (dir) rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe("buildMemorySystemPrompt", () => {
+  test("includes Auto Memory header", () => {
+    const repo = makeTempGitRepo()
+    const prompt = buildMemorySystemPrompt(repo)
+    expect(prompt).toContain("# Auto Memory")
+  })
+
+  test("includes memory directory path", () => {
+    const repo = makeTempGitRepo()
+    const memDir = getMemoryDir(repo)
+    const prompt = buildMemorySystemPrompt(repo)
+    expect(prompt).toContain(memDir)
+  })
+
+  test("includes all four memory types", () => {
+    const repo = makeTempGitRepo()
+    const prompt = buildMemorySystemPrompt(repo)
+    expect(prompt).toContain("<name>user</name>")
+    expect(prompt).toContain("<name>feedback</name>")
+    expect(prompt).toContain("<name>project</name>")
+    expect(prompt).toContain("<name>reference</name>")
+  })
+
+  test("includes types section with XML structure", () => {
+    const repo = makeTempGitRepo()
+    const prompt = buildMemorySystemPrompt(repo)
+    expect(prompt).toContain("<types>")
+    expect(prompt).toContain("</types>")
+    expect(prompt).toContain("<type>")
+    expect(prompt).toContain("</type>")
+  })
+
+  test("includes what NOT to save section", () => {
+    const repo = makeTempGitRepo()
+    const prompt = buildMemorySystemPrompt(repo)
+    expect(prompt).toContain("## What NOT to save in memory")
+    expect(prompt).toContain("Code patterns, conventions")
+    expect(prompt).toContain("Git history")
+  })
+
+  test("includes when to access section", () => {
+    const repo = makeTempGitRepo()
+    const prompt = buildMemorySystemPrompt(repo)
+    expect(prompt).toContain("## When to access memories")
+    expect(prompt).toContain("MUST access memory")
+  })
+
+  test("includes ignore-memory instruction", () => {
+    const repo = makeTempGitRepo()
+    const prompt = buildMemorySystemPrompt(repo)
+    expect(prompt).toContain("proceed as if MEMORY.md were empty")
+  })
+
+  test("includes trusting recall section", () => {
+    const repo = makeTempGitRepo()
+    const prompt = buildMemorySystemPrompt(repo)
+    expect(prompt).toContain("## Before recommending from memory")
+    expect(prompt).toContain("check the file exists")
+    expect(prompt).toContain("grep for it")
+  })
+
+  test("includes two-step save instructions", () => {
+    const repo = makeTempGitRepo()
+    const prompt = buildMemorySystemPrompt(repo)
+    expect(prompt).toContain("**Step 1**")
+    expect(prompt).toContain("**Step 2**")
+    expect(prompt).toContain("add a pointer")
+  })
+
+  test("includes frontmatter example", () => {
+    const repo = makeTempGitRepo()
+    const prompt = buildMemorySystemPrompt(repo)
+    expect(prompt).toContain("```markdown")
+    expect(prompt).toContain("name: {{memory name}}")
+    expect(prompt).toContain("type: {{user, feedback, project, reference}}")
+  })
+
+  test("includes persistence section", () => {
+    const repo = makeTempGitRepo()
+    const prompt = buildMemorySystemPrompt(repo)
+    expect(prompt).toContain("## Memory and other forms of persistence")
+    expect(prompt).toContain("use or update a plan instead of memory")
+    expect(prompt).toContain("use or update tasks instead of memory")
+  })
+
+  test("shows empty index message when no MEMORY.md exists", () => {
+    const repo = makeTempGitRepo()
+    const prompt = buildMemorySystemPrompt(repo)
+    expect(prompt).toContain(`## ${ENTRYPOINT_NAME}`)
+    expect(prompt).toContain("currently empty")
+  })
+
+  test("shows index content when MEMORY.md has content", () => {
+    const repo = makeTempGitRepo()
+    const entrypoint = getMemoryEntrypoint(repo)
+    writeFileSync(entrypoint, "- [My Memory](my_memory.md) — A test memory\n", "utf-8")
+
+    const prompt = buildMemorySystemPrompt(repo)
+    expect(prompt).toContain("My Memory")
+    expect(prompt).toContain("my_memory.md")
+    expect(prompt).not.toContain("currently empty")
+  })
+
+  test("appends recalled memories section when provided", () => {
+    const repo = makeTempGitRepo()
+    const recalledSection = "## Recalled Memories\n\n### Test (user)\nTest content"
+    const prompt = buildMemorySystemPrompt(repo, recalledSection)
+    expect(prompt).toContain("## Recalled Memories")
+    expect(prompt).toContain("### Test (user)")
+  })
+
+  test("omits recalled memories section when not provided", () => {
+    const repo = makeTempGitRepo()
+    const prompt = buildMemorySystemPrompt(repo)
+    expect(prompt).not.toContain("## Recalled Memories")
+  })
+
+  test("omits recalled memories section when empty string", () => {
+    const repo = makeTempGitRepo()
+    const prompt = buildMemorySystemPrompt(repo, "")
+    expect(prompt).not.toContain("## Recalled Memories")
+  })
+})

--- a/test/recall.test.ts
+++ b/test/recall.test.ts
@@ -220,6 +220,101 @@ describe("recallRelevantMemories", () => {
     expect(result).toHaveLength(1)
     expect(result[0]!.type).toBe("user")
   })
+
+  test("includes filePath in recalled memory", () => {
+    const repo = makeTempGitRepo()
+    const memDir = getMemoryDir(repo)
+
+    writeMemoryFile(
+      memDir,
+      "with_path.md",
+      { name: "Path Test", description: "Has file path", type: "user" },
+      "Test content",
+    )
+
+    const result = recallRelevantMemories(repo)
+    expect(result).toHaveLength(1)
+    expect(result[0]!.filePath).toContain("with_path.md")
+    expect(result[0]!.filePath).toContain(memDir)
+  })
+
+  test("weights name and description matches higher than content", () => {
+    const repo = makeTempGitRepo()
+    const memDir = getMemoryDir(repo)
+
+    writeMemoryFile(
+      memDir,
+      "desc_match.md",
+      { name: "Auth Config", description: "Authentication setup details", type: "project" },
+      "Unrelated body text about nothing",
+      new Date("2024-01-01"),
+    )
+    writeMemoryFile(
+      memDir,
+      "body_match.md",
+      { name: "Other Note", description: "Random unrelated description", type: "user" },
+      "The authentication setup is here",
+      new Date("2025-06-01"),
+    )
+
+    const result = recallRelevantMemories(repo, "authentication")
+    expect(result).toHaveLength(2)
+    expect(result[0]!.fileName).toBe("desc_match.md")
+  })
+
+  test("filters out reference memories for recently used tools", () => {
+    const repo = makeTempGitRepo()
+    const memDir = getMemoryDir(repo)
+
+    writeMemoryFile(
+      memDir,
+      "grep_ref.md",
+      { name: "Grep Tool API", description: "Usage reference for grep tool", type: "reference" },
+      "How to use the grep tool with various options",
+    )
+    writeMemoryFile(
+      memDir,
+      "other.md",
+      { name: "Project Setup", description: "Project configuration", type: "project" },
+      "General project info",
+    )
+
+    const result = recallRelevantMemories(repo, undefined, new Set(), ["grep"])
+    expect(result).toHaveLength(1)
+    expect(result[0]!.fileName).toBe("other.md")
+  })
+
+  test("keeps warning/gotcha reference memories even for recently used tools", () => {
+    const repo = makeTempGitRepo()
+    const memDir = getMemoryDir(repo)
+
+    writeMemoryFile(
+      memDir,
+      "grep_warning.md",
+      { name: "Grep Known Issues", description: "Warning about grep tool edge cases", type: "reference" },
+      "Known issue: grep fails on binary files",
+    )
+
+    const result = recallRelevantMemories(repo, undefined, new Set(), ["grep"])
+    expect(result).toHaveLength(1)
+    expect(result[0]!.fileName).toBe("grep_warning.md")
+  })
+
+  test("does not filter non-reference memories for recently used tools", () => {
+    const repo = makeTempGitRepo()
+    const memDir = getMemoryDir(repo)
+
+    writeMemoryFile(
+      memDir,
+      "grep_feedback.md",
+      { name: "Grep Preferences", description: "User prefers grep over find", type: "feedback" },
+      "Always use grep for searching",
+    )
+
+    const result = recallRelevantMemories(repo, undefined, new Set(), ["grep"])
+    expect(result).toHaveLength(1)
+    expect(result[0]!.fileName).toBe("grep_feedback.md")
+  })
 })
 
 describe("formatRecalledMemories", () => {
@@ -231,6 +326,7 @@ describe("formatRecalledMemories", () => {
     const memories: RecalledMemory[] = [
       {
         fileName: "test.md",
+        filePath: "/tmp/memory/test.md",
         name: "Test Memory",
         type: "user",
         description: "A test",
@@ -250,6 +346,7 @@ describe("formatRecalledMemories", () => {
     const memories: RecalledMemory[] = [
       {
         fileName: "old.md",
+        filePath: "/tmp/memory/old.md",
         name: "Old Memory",
         type: "project",
         description: "Old",
@@ -267,6 +364,7 @@ describe("formatRecalledMemories", () => {
     const memories: RecalledMemory[] = [
       {
         fileName: "fresh.md",
+        filePath: "/tmp/memory/fresh.md",
         name: "Fresh",
         type: "user",
         description: "Just created",
@@ -283,6 +381,7 @@ describe("formatRecalledMemories", () => {
     const memories: RecalledMemory[] = [
       {
         fileName: "a.md",
+        filePath: "/tmp/memory/a.md",
         name: "Memory A",
         type: "user",
         description: "First",
@@ -291,6 +390,7 @@ describe("formatRecalledMemories", () => {
       },
       {
         fileName: "b.md",
+        filePath: "/tmp/memory/b.md",
         name: "Memory B",
         type: "feedback",
         description: "Second",

--- a/test/recall.test.ts
+++ b/test/recall.test.ts
@@ -93,6 +93,31 @@ describe("recallRelevantMemories", () => {
     expect(result[0]!.fileName).toBe("auth.md")
   })
 
+  test("matches query against frontmatter name", () => {
+    const repo = makeTempGitRepo()
+    const memDir = getMemoryDir(repo)
+
+    writeMemoryFile(
+      memDir,
+      "auth.md",
+      { name: "Auth Config", description: "Setup note", type: "project" },
+      "Implementation details unrelated to title search",
+      new Date("2024-01-01"),
+    )
+    writeMemoryFile(
+      memDir,
+      "newer.md",
+      { name: "Recent Note", description: "More recent but not matching title", type: "user" },
+      "Fresh unrelated content",
+      new Date("2025-06-01"),
+    )
+
+    const result = recallRelevantMemories(repo, "Auth Config")
+    expect(result).toHaveLength(2)
+    expect(result[0]!.fileName).toBe("auth.md")
+    expect(result[0]!.name).toBe("Auth Config")
+  })
+
   test("respects alreadySurfaced filter", () => {
     const repo = makeTempGitRepo()
     const memDir = getMemoryDir(repo)
@@ -144,6 +169,22 @@ describe("recallRelevantMemories", () => {
     const result = recallRelevantMemories(repo)
     expect(result).toHaveLength(1)
     expect(result[0]!.name).toBe("plain_note")
+  })
+
+  test("prefers frontmatter name over filename slug", () => {
+    const repo = makeTempGitRepo()
+    const memDir = getMemoryDir(repo)
+
+    writeMemoryFile(
+      memDir,
+      "slug_only.md",
+      { name: "Readable Title", description: "Named memory", type: "user" },
+      "Named content",
+    )
+
+    const result = recallRelevantMemories(repo)
+    expect(result).toHaveLength(1)
+    expect(result[0]!.name).toBe("Readable Title")
   })
 
   test("calculates ageInDays correctly", () => {

--- a/test/recall.test.ts
+++ b/test/recall.test.ts
@@ -135,8 +135,7 @@ describe("recallRelevantMemories", () => {
       "Fresh content",
     )
 
-    const surfacedPath = join(memDir, "surfaced.md")
-    const result = recallRelevantMemories(repo, undefined, new Set([surfacedPath]))
+    const result = recallRelevantMemories(repo, undefined, new Set(["Already Shown|user"]))
 
     expect(result).toHaveLength(1)
     expect(result[0]!.fileName).toBe("fresh.md")

--- a/test/recall.test.ts
+++ b/test/recall.test.ts
@@ -1,0 +1,265 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, utimesSync } from "fs"
+import { tmpdir } from "os"
+import { join } from "path"
+import { recallRelevantMemories, formatRecalledMemories, type RecalledMemory } from "../src/recall.js"
+import { getMemoryDir } from "../src/paths.js"
+
+const tempDirs: string[] = []
+
+function makeTempGitRepo(): string {
+  const root = mkdtempSync(join(tmpdir(), "recall-test-"))
+  mkdirSync(join(root, ".git"), { recursive: true })
+  tempDirs.push(root)
+  return root
+}
+
+function writeMemoryFile(
+  memoryDir: string,
+  filename: string,
+  frontmatter: Record<string, string>,
+  body: string,
+  mtime?: Date,
+): void {
+  const fmLines = Object.entries(frontmatter).map(([k, v]) => `${k}: ${v}`)
+  const content = `---\n${fmLines.join("\n")}\n---\n\n${body}\n`
+  const filePath = join(memoryDir, filename)
+  writeFileSync(filePath, content, "utf-8")
+  if (mtime) {
+    utimesSync(filePath, mtime, mtime)
+  }
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop()
+    if (dir) rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe("recallRelevantMemories", () => {
+  test("returns empty array when no memories exist", () => {
+    const repo = makeTempGitRepo()
+    const result = recallRelevantMemories(repo)
+    expect(result).toEqual([])
+  })
+
+  test("returns memories sorted by mtime when no query", () => {
+    const repo = makeTempGitRepo()
+    const memDir = getMemoryDir(repo)
+
+    writeMemoryFile(
+      memDir,
+      "old.md",
+      { name: "Old Memory", description: "Old one", type: "user" },
+      "Old content",
+      new Date("2024-01-01"),
+    )
+    writeMemoryFile(
+      memDir,
+      "new.md",
+      { name: "New Memory", description: "New one", type: "feedback" },
+      "New content",
+      new Date("2025-06-01"),
+    )
+
+    const result = recallRelevantMemories(repo)
+    expect(result).toHaveLength(2)
+    expect(result[0]!.fileName).toBe("new.md")
+    expect(result[1]!.fileName).toBe("old.md")
+  })
+
+  test("scores and ranks by query relevance", () => {
+    const repo = makeTempGitRepo()
+    const memDir = getMemoryDir(repo)
+
+    writeMemoryFile(
+      memDir,
+      "auth.md",
+      { name: "Auth Config", description: "Authentication setup", type: "project" },
+      "JWT tokens and auth middleware",
+      new Date("2024-01-01"),
+    )
+    writeMemoryFile(
+      memDir,
+      "style.md",
+      { name: "Code Style", description: "Formatting rules", type: "feedback" },
+      "Use prettier with tabs",
+      new Date("2025-06-01"),
+    )
+
+    const result = recallRelevantMemories(repo, "authentication JWT")
+    expect(result).toHaveLength(2)
+    expect(result[0]!.fileName).toBe("auth.md")
+  })
+
+  test("respects alreadySurfaced filter", () => {
+    const repo = makeTempGitRepo()
+    const memDir = getMemoryDir(repo)
+
+    writeMemoryFile(
+      memDir,
+      "surfaced.md",
+      { name: "Already Shown", description: "Was already displayed", type: "user" },
+      "Surfaced content",
+    )
+    writeMemoryFile(
+      memDir,
+      "fresh.md",
+      { name: "Fresh", description: "Not yet shown", type: "user" },
+      "Fresh content",
+    )
+
+    const surfacedPath = join(memDir, "surfaced.md")
+    const result = recallRelevantMemories(repo, undefined, new Set([surfacedPath]))
+
+    expect(result).toHaveLength(1)
+    expect(result[0]!.fileName).toBe("fresh.md")
+  })
+
+  test("limits to MAX_RECALLED_MEMORIES (5)", () => {
+    const repo = makeTempGitRepo()
+    const memDir = getMemoryDir(repo)
+
+    for (let i = 0; i < 10; i++) {
+      writeMemoryFile(
+        memDir,
+        `mem_${i}.md`,
+        { name: `Memory ${i}`, description: `Desc ${i}`, type: "user" },
+        `Content ${i}`,
+        new Date(Date.now() - i * 86400_000),
+      )
+    }
+
+    const result = recallRelevantMemories(repo)
+    expect(result).toHaveLength(5)
+  })
+
+  test("extracts name from filename when no frontmatter name", () => {
+    const repo = makeTempGitRepo()
+    const memDir = getMemoryDir(repo)
+
+    writeFileSync(join(memDir, "plain_note.md"), "Just plain text, no frontmatter\n", "utf-8")
+
+    const result = recallRelevantMemories(repo)
+    expect(result).toHaveLength(1)
+    expect(result[0]!.name).toBe("plain_note")
+  })
+
+  test("calculates ageInDays correctly", () => {
+    const repo = makeTempGitRepo()
+    const memDir = getMemoryDir(repo)
+
+    const threeDaysAgo = new Date(Date.now() - 3 * 86400_000)
+    writeMemoryFile(
+      memDir,
+      "aged.md",
+      { name: "Aged", description: "Three days old", type: "user" },
+      "Old content",
+      threeDaysAgo,
+    )
+
+    const result = recallRelevantMemories(repo)
+    expect(result).toHaveLength(1)
+    expect(result[0]!.ageInDays).toBe(3)
+  })
+
+  test("defaults type to 'user' when missing", () => {
+    const repo = makeTempGitRepo()
+    const memDir = getMemoryDir(repo)
+
+    writeMemoryFile(
+      memDir,
+      "notype.md",
+      { name: "No Type", description: "Missing type field" },
+      "Content without type",
+    )
+
+    const result = recallRelevantMemories(repo)
+    expect(result).toHaveLength(1)
+    expect(result[0]!.type).toBe("user")
+  })
+})
+
+describe("formatRecalledMemories", () => {
+  test("returns empty string for empty array", () => {
+    expect(formatRecalledMemories([])).toBe("")
+  })
+
+  test("formats recalled memories with headers", () => {
+    const memories: RecalledMemory[] = [
+      {
+        fileName: "test.md",
+        name: "Test Memory",
+        type: "user",
+        description: "A test",
+        content: "Hello world",
+        ageInDays: 0,
+      },
+    ]
+
+    const result = formatRecalledMemories(memories)
+    expect(result).toContain("## Recalled Memories")
+    expect(result).toContain("### Test Memory (user)")
+    expect(result).toContain("Hello world")
+    expect(result).toContain("automatically selected as relevant")
+  })
+
+  test("includes age warning for memories older than 1 day", () => {
+    const memories: RecalledMemory[] = [
+      {
+        fileName: "old.md",
+        name: "Old Memory",
+        type: "project",
+        description: "Old",
+        content: "Old content",
+        ageInDays: 5,
+      },
+    ]
+
+    const result = formatRecalledMemories(memories)
+    expect(result).toContain("5 days old")
+    expect(result).toContain("point-in-time observations")
+  })
+
+  test("no age warning for fresh memories", () => {
+    const memories: RecalledMemory[] = [
+      {
+        fileName: "fresh.md",
+        name: "Fresh",
+        type: "user",
+        description: "Just created",
+        content: "Fresh content",
+        ageInDays: 0,
+      },
+    ]
+
+    const result = formatRecalledMemories(memories)
+    expect(result).not.toContain("days old")
+  })
+
+  test("formats multiple memories", () => {
+    const memories: RecalledMemory[] = [
+      {
+        fileName: "a.md",
+        name: "Memory A",
+        type: "user",
+        description: "First",
+        content: "Content A",
+        ageInDays: 0,
+      },
+      {
+        fileName: "b.md",
+        name: "Memory B",
+        type: "feedback",
+        description: "Second",
+        content: "Content B",
+        ageInDays: 0,
+      },
+    ]
+
+    const result = formatRecalledMemories(memories)
+    expect(result).toContain("### Memory A (user)")
+    expect(result).toContain("### Memory B (feedback)")
+  })
+})


### PR DESCRIPTION
## Summary

- **Add `memoryScan.ts`**: Recursive memory directory scanner with frontmatter parsing, ported from Claude Code's `memoryScan.ts`
- **Align core modules** (`memory.ts`, `prompt.ts`, `recall.ts`) with Claude Code's `src/memdir/` implementation
- **Add comprehensive test suite**: 76 tests across 7 files (72 new), covering unit tests for all modules + integration lifecycle test
- **Update docs**: `AGENTS.md` and `README.md` updated to reflect new module structure, coupling diagram, and Claude Code alignment notes

## What changed

### New file: `src/memoryScan.ts`
- `scanMemoryFiles()`: Recursive scan, reads only frontmatter headers, sorts by mtime desc, capped at `MAX_MEMORY_FILES`
- `formatMemoryManifest()`: Formats `MemoryHeader[]` into manifest lines
- `getMemoryManifest()`: Convenience wrapper for worktree → headers + manifest

### `src/memory.ts`
- `truncateEntrypoint()` rewritten to match Claude Code's `truncateEntrypointContent()` — returns `EntrypointTruncation` with `content`, `lineCount`, `byteCount`, `wasLineTruncated`, `wasByteTruncated`
- Uses `.length` (char count) instead of `Buffer.byteLength`, matching Claude Code's actual implementation

### `src/prompt.ts`
- Rewritten to closely match Claude Code's `memoryTypes.ts` + `memdir.ts`:
  - `TYPES_SECTION` aligned with `TYPES_SECTION_INDIVIDUAL` (detailed XML-structured type descriptions)
  - Two-step save instructions (write file → add pointer to `MEMORY.md`)
  - `TRUSTING_RECALL` section with verify-before-recommending guidance
  - `WHEN_TO_ACCESS` section with explicit ignore-memory instruction

### `src/recall.ts`
- Rewritten to use `scanMemoryFiles()` + `MemoryHeader` instead of `listMemories()` + `statSync`
- Added `alreadySurfaced: ReadonlySet<string>` support to prevent double-recall
- Keyword-based scoring via `scoreHeader()` (heuristic, since plugin environment has no LLM side-query)

### Tests (all new except 2 existing)
| File | Tests | Coverage |
|---|---|---|
| `test/memoryScan.test.ts` | 10 | scan, frontmatter parsing, manifest formatting |
| `test/memory.test.ts` | 16 | truncateEntrypoint, CRUD, index management |
| `test/recall.test.ts` | 10 | recall scoring, filtering, formatting |
| `test/prompt.test.ts` | 14 | system prompt structure and content |
| `test/integration.test.ts` | 4 | end-to-end lifecycle |

### Docs
- `AGENTS.md`: Added `memoryScan.ts` to structure/coupling, updated conventions (tests exist now), added Claude Code alignment notes
- `README.md`: Added compatibility detail table and development section

## Test results

```
bun test v1.3.5
 76 pass
 0 fail
 207 expect() calls
Ran 76 tests across 7 files.
```