### PR TITLE
fix: build dist before npm publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,10 +17,17 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.11
+
       - uses: actions/setup-node@v4
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: bun install
 
       - name: Release
         run: npx semantic-release@25

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ If you rename or change exports in `paths.ts` or `memory.ts`, check all downstre
 
 - **ESM `.js` imports**: All TypeScript imports use `.js` extension (`import { foo } from "./bar.js"`)
 - **No linter/formatter**: No eslintrc, prettierrc — no enforced style
-- **No build**: `main` and `exports` in package.json point to `src/index.ts` directly
+- **Published package is built**: `tsc` emits `dist/`, and npm publishes the compiled output
 - **Tests via Bun**: `bun test` runs all `test/*.test.ts` files
 - **Silent catch blocks**: Intentional — file operations fail gracefully (file may not exist)
 - **`@opencode-ai/plugin`** is a peerDependency, `bun-types` provides Node globals
@@ -91,15 +91,16 @@ If you rename or change exports in `paths.ts` or `memory.ts`, check all downstre
 ## Commands
 
 ```bash
-# No build needed — raw TS consumed by OpenCode
-
 # Run tests
 bun test
+
+# Build published artifacts
+bun run build
 
 # Release: push to main triggers semantic-release → npm publish
 git push origin main
 
-# Local dev: just edit src/ and test with opencode directly
+# Local dev: edit src/, then run build if you need the packaged entrypoints
 ```
 
 ## Notes

--- a/README.md
+++ b/README.md
@@ -230,7 +230,9 @@ Supported memory types:
 # Run tests
 bun test
 
-# No build needed — raw TS consumed by OpenCode
+# Build published artifacts
+bun run build
+
 # Release: push to main triggers semantic-release → npm publish
 ```
 

--- a/package.json
+++ b/package.json
@@ -3,17 +3,25 @@
   "version": "0.0.0-semantically-released",
   "type": "module",
   "description": "Claude Code-compatible memory compatibility layer for OpenCode — zero config, local-first, no migration",
-  "main": "src/index.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "bin": {
     "opencode-memory": "./bin/opencode-memory"
   },
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   },
   "files": [
-    "src",
-    "bin"
+    "dist"
   ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "prepack": "npm run build"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kuitos/opencode-claude-memory.git"
@@ -36,6 +44,7 @@
   },
   "devDependencies": {
     "bun-types": "^1.3.11",
-    "@opencode-ai/plugin": "^1.3.10"
+    "@opencode-ai/plugin": "^1.3.10",
+    "typescript": "^6.0.2"
   }
 }

--- a/test/publish-config.test.ts
+++ b/test/publish-config.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test"
+import { existsSync, readFileSync } from "fs"
+import { join } from "path"
+
+const packagePath = join(process.cwd(), "package.json")
+const releaseWorkflowPath = join(process.cwd(), ".github", "workflows", "publish.yml")
+
+type PackageJson = {
+  main?: string
+  types?: string
+  exports?: unknown
+  files?: string[]
+  scripts?: Record<string, string>
+}
+
+describe("package publish config", () => {
+  test("publishes compiled entrypoints from dist and builds before packing", () => {
+    expect(existsSync(packagePath)).toBe(true)
+
+    const pkg = JSON.parse(readFileSync(packagePath, "utf-8")) as PackageJson
+
+    expect(pkg.main).toBe("dist/index.js")
+    expect(pkg.types).toBe("dist/index.d.ts")
+    expect(pkg.exports).toEqual({
+      ".": {
+        types: "./dist/index.d.ts",
+        import: "./dist/index.js",
+        default: "./dist/index.js",
+      },
+    })
+    expect(pkg.files).toEqual(["dist"])
+    expect(pkg.scripts?.build).toBe("tsc -p tsconfig.json")
+    expect(pkg.scripts?.prepack).toBe("npm run build")
+  })
+
+  test("installs dependencies before semantic-release publishes", () => {
+    expect(existsSync(releaseWorkflowPath)).toBe(true)
+
+    const workflow = readFileSync(releaseWorkflowPath, "utf-8")
+
+    expect(workflow).toContain("oven-sh/setup-bun")
+    expect(workflow).toContain("bun install")
+    expect(workflow).toContain("npx semantic-release@25")
+  })
+})


### PR DESCRIPTION
## Summary
- switch the published package entrypoints from `src` to compiled `dist` output
- add `build`/`prepack` scripts so `tsc` runs before npm packaging
- update the release workflow to install dependencies before `semantic-release`
- add a regression test covering package publish config and release workflow expectations

## Why
The package previously published raw TypeScript from `src` with no build step in the release flow. This change makes npm publish compiled JavaScript from `dist` instead.

## Validation
- `bun test`
- `bun run build`
- `npm pack --dry-run --json`
