### PR TITLE
fix: enable manual publish dispatch for release backfills

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   release:

--- a/test/publish-config.test.ts
+++ b/test/publish-config.test.ts
@@ -38,6 +38,7 @@ describe("package publish config", () => {
 
     const workflow = readFileSync(releaseWorkflowPath, "utf-8")
 
+    expect(workflow).toContain("workflow_dispatch:")
     expect(workflow).toContain("oven-sh/setup-bun")
     expect(workflow).toContain("bun install")
     expect(workflow).toContain("npx semantic-release@25")


### PR DESCRIPTION
## What changed
- add `workflow_dispatch` to the release workflow so publish can be run manually from GitHub Actions when a backfill is needed
- extend the publish config test to keep that manual trigger covered

## Why
The recent `Release` workflow run on `main` completed successfully, but `semantic-release` skipped publishing because the only commit since `v1.6.0` was not releasable. This PR adds a real `fix:` change so merging it will trigger the next patch release, and it also leaves a manual publish path in place for future operational backfills.

## Impact
- merging this PR should allow the repository to publish `1.6.1`
- maintainers can manually dispatch the publish workflow later if a release needs to be re-run

## Validation
- `bun test test/publish-config.test.ts test/github-actions-ci.test.ts`
- full `bun test` still has the pre-existing `@opencode-ai/plugin` resolution error in `test/index.test.ts`, unrelated to this PR
