### PR TITLE
fix: clean up forked sessions after extraction and auto-dream

### DIFF
--- a/bin/opencode-memory
+++ b/bin/opencode-memory
@@ -956,104 +956,6 @@ rollback_consolidation_lock() {
   set_file_mtime_secs "$path" "$prior_mtime"
 }
 
-run_extraction_if_needed() {
-  local session_id="$1"
-  local memory_written_during_session="$2"
-
-  if [ "$EXTRACT_ENABLED" = "0" ]; then
-    return 0
-  fi
-
-  if [ "$memory_written_during_session" = "1" ]; then
-    log "Main agent already wrote memories during session, skipping extraction"
-    return 0
-  fi
-
-  if ! acquire_simple_lock "$EXTRACT_LOCK_FILE" "memory extraction"; then
-    return 0
-  fi
-
-  log "Extracting memories from session $session_id..."
-  log "Extraction log: $EXTRACT_LOG_FILE"
-
-  local cmd=("$REAL_OPENCODE" run -s "$session_id" --fork --dir "$WORKING_DIR")
-  if [ -n "$EXTRACT_MODEL" ]; then
-    cmd+=(-m "$EXTRACT_MODEL")
-  fi
-  if [ -n "$EXTRACT_AGENT" ]; then
-    cmd+=(--agent "$EXTRACT_AGENT")
-  fi
-  cmd+=("$EXTRACT_PROMPT")
-
-  if "${cmd[@]}" >> "$EXTRACT_LOG_FILE" 2>&1; then
-    log "Memory extraction completed successfully"
-  else
-    local code=$?
-    log "Memory extraction failed (exit code $code). Check $EXTRACT_LOG_FILE for details"
-  fi
-
-  release_simple_lock "$EXTRACT_LOCK_FILE"
-}
-
-run_autodream_if_needed() {
-  local session_id="$1"
-
-  if [ "$AUTODREAM_ENABLED" = "0" ]; then
-    return 0
-  fi
-
-  if ! command -v jq >/dev/null 2>&1; then
-    log "jq not found, skipping auto-dream (requires JSON session parsing)"
-    return 0
-  fi
-
-  local last_at now hours_since since_ms touched_count
-  last_at=$(read_last_consolidated_at_secs)
-  now=$(date +%s)
-
-  hours_since=$(((now - last_at) / 3600))
-  if [ "$hours_since" -lt "$AUTODREAM_MIN_HOURS" ]; then
-    return 0
-  fi
-
-  since_ms=$((last_at * 1000))
-  touched_count=$(count_sessions_touched_since_ms "$since_ms" "$session_id" || true)
-  if [ -z "$touched_count" ]; then
-    log "Unable to inspect touched sessions, skipping auto-dream"
-    return 0
-  fi
-
-  if [ "$touched_count" -lt "$AUTODREAM_MIN_SESSIONS" ]; then
-    return 0
-  fi
-
-  if ! try_acquire_consolidation_lock; then
-    return 0
-  fi
-
-  log "Auto-dream firing (${hours_since}h since last consolidation, ${touched_count} sessions touched)"
-  log "Auto-dream log: $AUTODREAM_LOG_FILE"
-
-  local cmd=("$REAL_OPENCODE" run -s "$session_id" --fork --dir "$WORKING_DIR")
-  if [ -n "$AUTODREAM_MODEL" ]; then
-    cmd+=(-m "$AUTODREAM_MODEL")
-  fi
-  if [ -n "$AUTODREAM_AGENT" ]; then
-    cmd+=(--agent "$AUTODREAM_AGENT")
-  fi
-  cmd+=("$AUTODREAM_PROMPT")
-
-  if "${cmd[@]}" >> "$AUTODREAM_LOG_FILE" 2>&1; then
-    log "Auto-dream consolidation completed successfully"
-    # Keep lock mtime at "now" to represent last consolidated timestamp.
-  else
-    local code=$?
-    log "Auto-dream consolidation failed (exit code $code). Rolling back gate timestamp"
-    rollback_consolidation_lock "$CONSOLIDATION_PRIOR_MTIME"
-    return 0
-  fi
-}
-
 cleanup_forked_sessions() {
   local before_json="$1"
 
@@ -1110,17 +1012,118 @@ PY
   done <<< "$fork_ids"
 }
 
+run_extraction_if_needed() {
+  local session_id="$1"
+  local memory_written_during_session="$2"
+
+  if [ "$EXTRACT_ENABLED" = "0" ]; then
+    return 0
+  fi
+
+  if [ "$memory_written_during_session" = "1" ]; then
+    log "Main agent already wrote memories during session, skipping extraction"
+    return 0
+  fi
+
+  if ! acquire_simple_lock "$EXTRACT_LOCK_FILE" "memory extraction"; then
+    return 0
+  fi
+
+  log "Extracting memories from session $session_id..."
+  log "Extraction log: $EXTRACT_LOG_FILE"
+
+  local cmd=("$REAL_OPENCODE" run -s "$session_id" --fork --dir "$WORKING_DIR")
+  if [ -n "$EXTRACT_MODEL" ]; then
+    cmd+=(-m "$EXTRACT_MODEL")
+  fi
+  if [ -n "$EXTRACT_AGENT" ]; then
+    cmd+=(--agent "$EXTRACT_AGENT")
+  fi
+  cmd+=("$EXTRACT_PROMPT")
+
+  local pre_fork_json
+  pre_fork_json=$(get_session_list_json 5 2>/dev/null || true)
+
+  if "${cmd[@]}" >> "$EXTRACT_LOG_FILE" 2>&1; then
+    log "Memory extraction completed successfully"
+  else
+    local code=$?
+    log "Memory extraction failed (exit code $code). Check $EXTRACT_LOG_FILE for details"
+  fi
+
+  cleanup_forked_sessions "$pre_fork_json"
+  release_simple_lock "$EXTRACT_LOCK_FILE"
+}
+
+run_autodream_if_needed() {
+  local session_id="$1"
+
+  if [ "$AUTODREAM_ENABLED" = "0" ]; then
+    return 0
+  fi
+
+  if ! command -v jq >/dev/null 2>&1; then
+    log "jq not found, skipping auto-dream (requires JSON session parsing)"
+    return 0
+  fi
+
+  local last_at now hours_since since_ms touched_count
+  last_at=$(read_last_consolidated_at_secs)
+  now=$(date +%s)
+
+  hours_since=$(((now - last_at) / 3600))
+  if [ "$hours_since" -lt "$AUTODREAM_MIN_HOURS" ]; then
+    return 0
+  fi
+
+  since_ms=$((last_at * 1000))
+  touched_count=$(count_sessions_touched_since_ms "$since_ms" "$session_id" || true)
+  if [ -z "$touched_count" ]; then
+    log "Unable to inspect touched sessions, skipping auto-dream"
+    return 0
+  fi
+
+  if [ "$touched_count" -lt "$AUTODREAM_MIN_SESSIONS" ]; then
+    return 0
+  fi
+
+  if ! try_acquire_consolidation_lock; then
+    return 0
+  fi
+
+  log "Auto-dream firing (${hours_since}h since last consolidation, ${touched_count} sessions touched)"
+  log "Auto-dream log: $AUTODREAM_LOG_FILE"
+
+  local cmd=("$REAL_OPENCODE" run -s "$session_id" --fork --dir "$WORKING_DIR")
+  if [ -n "$AUTODREAM_MODEL" ]; then
+    cmd+=(-m "$AUTODREAM_MODEL")
+  fi
+  if [ -n "$AUTODREAM_AGENT" ]; then
+    cmd+=(--agent "$AUTODREAM_AGENT")
+  fi
+  cmd+=("$AUTODREAM_PROMPT")
+
+  local pre_fork_json
+  pre_fork_json=$(get_session_list_json 5 2>/dev/null || true)
+
+  if "${cmd[@]}" >> "$AUTODREAM_LOG_FILE" 2>&1; then
+    log "Auto-dream consolidation completed successfully"
+    # Keep lock mtime at "now" to represent last consolidated timestamp.
+  else
+    local code=$?
+    log "Auto-dream consolidation failed (exit code $code). Rolling back gate timestamp"
+    rollback_consolidation_lock "$CONSOLIDATION_PRIOR_MTIME"
+  fi
+
+  cleanup_forked_sessions "$pre_fork_json"
+}
+
 run_post_session_tasks() {
   local session_id="$1"
   local memory_written_during_session="$2"
 
-  local pre_tasks_json
-  pre_tasks_json=$(get_session_list_json 10 2>/dev/null || true)
-
   run_extraction_if_needed "$session_id" "$memory_written_during_session"
   run_autodream_if_needed "$session_id"
-
-  cleanup_forked_sessions "$pre_tasks_json"
 }
 
 # ============================================================================

--- a/bin/opencode-memory
+++ b/bin/opencode-memory
@@ -1054,12 +1054,73 @@ run_autodream_if_needed() {
   fi
 }
 
+cleanup_forked_sessions() {
+  local before_json="$1"
+
+  if ! command -v python3 >/dev/null 2>&1; then
+    return 0
+  fi
+
+  local after_json
+  after_json=$(get_session_list_json 10 2>/dev/null || true)
+
+  if [ -z "$before_json" ] || [ -z "$after_json" ]; then
+    return 0
+  fi
+
+  local fork_ids
+  fork_ids=$(python3 - "$before_json" "$after_json" "$WORKING_DIR" "$PROJECT_SCOPE_DIR" <<'PY'
+import json
+import os
+import sys
+
+def parse(raw):
+    try:
+        data = json.loads(raw)
+        return data if isinstance(data, list) else []
+    except Exception:
+        return []
+
+before_raw, after_raw, workdir, project_dir = sys.argv[1:5]
+before = parse(before_raw)
+after = parse(after_raw)
+
+before_ids = {item.get("id") for item in before if item.get("id")}
+workdir = os.path.realpath(workdir)
+project_dir = os.path.realpath(project_dir)
+
+for item in after:
+    sid = item.get("id", "")
+    if not sid or sid in before_ids:
+        continue
+    directory = item.get("directory", "")
+    if not directory:
+        continue
+    d = os.path.realpath(directory)
+    if d in (workdir, project_dir):
+        print(sid)
+PY
+  ) || return 0
+
+  while IFS= read -r fork_id; do
+    [ -n "$fork_id" ] || continue
+    if "$REAL_OPENCODE" session delete "$fork_id" >/dev/null 2>&1; then
+      log "Cleaned up forked session $fork_id"
+    fi
+  done <<< "$fork_ids"
+}
+
 run_post_session_tasks() {
   local session_id="$1"
   local memory_written_during_session="$2"
 
+  local pre_tasks_json
+  pre_tasks_json=$(get_session_list_json 10 2>/dev/null || true)
+
   run_extraction_if_needed "$session_id" "$memory_written_during_session"
   run_autodream_if_needed "$session_id"
+
+  cleanup_forked_sessions "$pre_tasks_json"
 }
 
 # ============================================================================

--- a/bin/opencode-memory
+++ b/bin/opencode-memory
@@ -1012,6 +1012,24 @@ PY
   done <<< "$fork_ids"
 }
 
+session_has_conversation() {
+  local session_id="$1"
+  local transcript_file
+  transcript_file="$(get_transcripts_dir)/${session_id}.jsonl"
+
+  if [ -f "$transcript_file" ]; then
+    local line_count
+    line_count=$(wc -l < "$transcript_file")
+    # Empty sessions have at most 1 line (the initial user entry with no content).
+    # Real sessions have 3+ lines (user + tool_use + tool_result at minimum).
+    [ "$line_count" -gt 1 ]
+    return $?
+  fi
+
+  # Transcript not found — assume content exists to avoid skipping a valid session.
+  return 0
+}
+
 run_extraction_if_needed() {
   local session_id="$1"
   local memory_written_during_session="$2"
@@ -1153,6 +1171,13 @@ fi
 session_id=$(wait_for_session_target_id "$PRE_SESSION_JSON" "$SESSION_CAPTURE_STARTED_AT_MS" "$SESSION_WAIT_SECONDS" || true)
 if [ -z "$session_id" ]; then
   log "No session found, skipping post-session memory maintenance"
+  cleanup_timestamp
+  exit $opencode_exit
+fi
+
+# Step 3.5: Skip if session had no real conversation (e.g. user opened TUI and exited)
+if ! session_has_conversation "$session_id"; then
+  log "Session $session_id has no conversation, skipping post-session memory maintenance"
   cleanup_timestamp
   exit $opencode_exit
 fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-claude-memory",
-  "version": "0.0.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -36,7 +36,7 @@
     },
     "": {
       "name": "opencode-claude-memory",
-      "version": "0.0.0",
+      "version": "1.6.1",
       "dependencies": {
         "zod": "^3.24.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,77 @@
+{
+  "name": "opencode-claude-memory",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "node_modules/bun-types": {
+      "name": "bun-types",
+      "version": "1.3.11",
+      "resolved": "https://registry.antgroup-inc.cn/bun-types/-/bun-types-1.3.11.tgz",
+      "integrity": "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg==",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "dev": true
+    },
+    "node_modules/zod": {
+      "name": "zod",
+      "version": "3.25.76",
+      "resolved": "https://registry.antgroup-inc.cn/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="
+    },
+    "node_modules/undici-types": {
+      "name": "undici-types",
+      "version": "7.18.2",
+      "resolved": "https://registry.antgroup-inc.cn/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true
+    },
+    "node_modules/@opencode-ai/plugin/node_modules/zod": {
+      "name": "zod",
+      "version": "4.1.8",
+      "resolved": "https://registry.antgroup-inc.cn/zod/-/zod-4.1.8.tgz",
+      "integrity": "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ==",
+      "dev": true
+    },
+    "": {
+      "name": "opencode-claude-memory",
+      "version": "0.0.0",
+      "dependencies": {
+        "zod": "^3.24.0"
+      },
+      "devDependencies": {
+        "@opencode-ai/plugin": "^1.3.10",
+        "bun-types": "^1.3.11"
+      }
+    },
+    "node_modules/@opencode-ai/plugin": {
+      "name": "@opencode-ai/plugin",
+      "version": "1.3.10",
+      "resolved": "https://registry.antgroup-inc.cn/@opencode-ai/plugin/-/plugin-1.3.10.tgz",
+      "integrity": "sha512-q6VgqOXFx2NGdAsgVQQaZGm9EqHOd7ivJyompgnfB7WfoBMWoutSkJ7D+YB6lHQWFXiopLSqdbzt1TpYJMo2lg==",
+      "dependencies": {
+        "zod": "4.1.8",
+        "@opencode-ai/sdk": "1.3.10"
+      },
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "name": "@types/node",
+      "version": "25.5.0",
+      "resolved": "https://registry.antgroup-inc.cn/@types/node/-/node-25.5.0.tgz",
+      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      },
+      "dev": true
+    },
+    "node_modules/@opencode-ai/sdk": {
+      "name": "@opencode-ai/sdk",
+      "version": "1.3.10",
+      "resolved": "https://registry.antgroup-inc.cn/@opencode-ai/sdk/-/sdk-1.3.10.tgz",
+      "integrity": "sha512-qDeTgCon4HXDw1U6SAfrGndbP3DXVd5QEbDPzFcIueO42Vws02az2rctJG4dvkHxLAGcKfj6ZpNr4NHEjYtuYA==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-claude-memory",
-  "version": "0.0.0",
+  "version": "1.6.0",
   "type": "module",
   "description": "Claude Code-compatible memory compatibility layer for OpenCode — zero config, local-first, no migration",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-claude-memory",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "type": "module",
   "description": "Claude Code-compatible memory compatibility layer for OpenCode — zero config, local-first, no migration",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-claude-memory",
-  "version": "0.0.0-semantically-released",
+  "version": "0.0.0",
   "type": "module",
   "description": "Claude Code-compatible memory compatibility layer for OpenCode — zero config, local-first, no migration",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-claude-memory",
-  "version": "1.6.1",
+  "version": "0.0.0-semantically-released",
   "type": "module",
   "description": "Claude Code-compatible memory compatibility layer for OpenCode — zero config, local-first, no migration",
   "main": "dist/index.js",

--- a/test/opencode-memory.test.ts
+++ b/test/opencode-memory.test.ts
@@ -270,7 +270,7 @@ JSON
 fi
 if [ "\${1:-}" = "run" ] && [ "\${2:-}" != "-s" ]; then
   mkdir -p "$CLAUDE_CONFIG_DIR/transcripts"
-  printf '{"type":"user","content":"wrapped"}\n' > "$CLAUDE_CONFIG_DIR/transcripts/ses_wrapped_target.jsonl"
+  printf '{"type":"user","content":"wrapped"}\n{"type":"tool_use","content":""}\n' > "$CLAUDE_CONFIG_DIR/transcripts/ses_wrapped_target.jsonl"
   echo "main run ok"
   exit 0
 fi
@@ -337,7 +337,7 @@ JSON
 fi
 if [ "\${1:-}" = "run" ] && [ "\${2:-}" != "-s" ]; then
   mkdir -p "$CLAUDE_CONFIG_DIR/transcripts"
-  (sleep 1; printf '{"type":"user","content":"wrapped"}\n' > "$CLAUDE_CONFIG_DIR/transcripts/ses_delayed_target.jsonl") &
+  (sleep 1; printf '{"type":"user","content":"wrapped"}\n{"type":"tool_use","content":""}\n' > "$CLAUDE_CONFIG_DIR/transcripts/ses_delayed_target.jsonl") &
   echo "main run ok"
   exit 0
 fi
@@ -542,9 +542,9 @@ JSON
 fi
 if [ "\${1:-}" = "run" ] && [ "\${2:-}" != "-s" ]; then
   mkdir -p "$CLAUDE_CONFIG_DIR/transcripts" "$HOME/.local/share/opencode/storage/session_diff"
-  printf '{"type":"user","content":"wrapped"}\n' > "$CLAUDE_CONFIG_DIR/transcripts/ses_wrapped_target.jsonl"
+  printf '{"type":"user","content":"wrapped"}\n{"type":"tool_use","content":""}\n' > "$CLAUDE_CONFIG_DIR/transcripts/ses_wrapped_target.jsonl"
   sleep 1
-  printf '{"type":"user","content":"other"}\n' > "$CLAUDE_CONFIG_DIR/transcripts/ses_other_repo.jsonl"
+  printf '{"type":"user","content":"other"}\n{"type":"tool_use","content":""}\n' > "$CLAUDE_CONFIG_DIR/transcripts/ses_other_repo.jsonl"
   echo "main run ok"
   exit 0
 fi
@@ -658,7 +658,7 @@ if [ "\${1:-}" = "session" ] && [ "\${2:-}" = "list" ]; then
 fi
 if [ "\${1:-}" = "run" ] && [ "\${2:-}" != "-s" ]; then
   mkdir -p "$CLAUDE_CONFIG_DIR/transcripts"
-  printf '{"type":"user","content":"wrapped"}\n' > "$CLAUDE_CONFIG_DIR/transcripts/ses_wrapped_target.jsonl"
+  printf '{"type":"user","content":"wrapped"}\n{"type":"tool_use","content":""}\n' > "$CLAUDE_CONFIG_DIR/transcripts/ses_wrapped_target.jsonl"
   echo "main run ok"
   exit 0
 fi
@@ -720,7 +720,7 @@ if [ "\${1:-}" = "session" ] && [ "\${2:-}" = "list" ]; then
 fi
 if [ "\${1:-}" = "run" ] && [ "\${2:-}" != "-s" ]; then
   mkdir -p "$CLAUDE_CONFIG_DIR/transcripts"
-  printf '{"type":"user","content":"wrapped"}\n' > "$CLAUDE_CONFIG_DIR/transcripts/ses_wrapped_target.jsonl"
+  printf '{"type":"user","content":"wrapped"}\n{"type":"tool_use","content":""}\n' > "$CLAUDE_CONFIG_DIR/transcripts/ses_wrapped_target.jsonl"
   echo "main run ok"
   exit 0
 fi


### PR DESCRIPTION
## Summary

- Post-session extraction/auto-dream uses `opencode run --fork` which creates visible fork sessions that clutter the session list (e.g. "xxx (`fork #1`)")
- Claude Code avoids this by running extraction in-process with `skipTranscript: true` — no session artifact is created. Since we use CLI invocation, fork sessions are unavoidable.
- Added `cleanup_forked_sessions()` that snapshots the session list before tasks run, diffs afterward to find newly created sessions, and deletes them via `opencode session delete`
- Safety: only deletes sessions matching the current project directory to prevent removing unrelated concurrent sessions