### PR TITLE
fix: Fix root worktree memory path resolution

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import type { Plugin } from "@opencode-ai/plugin"
 import { tool } from "@opencode-ai/plugin"
+import { parse, resolve } from "path"
 import { buildMemorySystemPrompt } from "./prompt.js"
 import { formatRecalledMemories, recallSelectedMemories, type RecalledMemory } from "./recall.js"
 import { assertSupportedRecallSelectorClient, selectRelevantMemoryFilenames, type SessionClient } from "./recallSelector.js"
@@ -154,6 +155,16 @@ function getRecallModel(): { providerID: string; modelID: string } | undefined {
   }
 }
 
+function isRootPath(path: string): boolean {
+  const resolved = resolve(path)
+  return resolved === parse(resolved).root
+}
+
+function resolveMemoryRoot(worktree: string, directory: string): string {
+  if (isRootPath(worktree) && !isRootPath(directory)) return directory
+  return worktree
+}
+
 function isUsefulRecallQuery(query: string | undefined): query is string {
   const trimmed = query?.trim()
   if (!trimmed) return false
@@ -283,7 +294,8 @@ function getCallID(ctx: unknown): string | undefined {
 
 export const MemoryPlugin: Plugin = async ({ worktree, directory, client }) => {
   directory ??= worktree
-  getMemoryDir(worktree)
+  const memoryRoot = resolveMemoryRoot(worktree, directory)
+  getMemoryDir(memoryRoot)
 
   return {
     config: async (config) => {
@@ -348,7 +360,7 @@ export const MemoryPlugin: Plugin = async ({ worktree, directory, client }) => {
             : startRecallPrefetch({
               client: client as unknown as SessionClient,
               directory,
-              worktree,
+              worktree: memoryRoot,
               parentSessionID: sessionID,
               turnID,
               query,
@@ -389,7 +401,7 @@ export const MemoryPlugin: Plugin = async ({ worktree, directory, client }) => {
       const recalled = ignoreMemoryContext ? [] : consumeRecallPrefetch(ctx)
 
       const recalledSection = formatRecalledMemories(recalled)
-      const memoryPrompt = buildMemorySystemPrompt(worktree, recalledSection, {
+      const memoryPrompt = buildMemorySystemPrompt(memoryRoot, recalledSection, {
         includeIndex: !ignoreMemoryContext,
       })
       output.system.push(memoryPrompt)
@@ -426,7 +438,7 @@ export const MemoryPlugin: Plugin = async ({ worktree, directory, client }) => {
             ),
         },
         async execute(args, _ctx) {
-          const filePath = saveMemory(worktree, args.file_name, args.name, args.description, args.type, args.content)
+          const filePath = saveMemory(memoryRoot, args.file_name, args.name, args.description, args.type, args.content)
           return `Memory saved to ${filePath}`
         },
       }),
@@ -437,7 +449,7 @@ export const MemoryPlugin: Plugin = async ({ worktree, directory, client }) => {
           file_name: tool.schema.string().describe("File name of the memory to delete (with or without .md extension)"),
         },
         async execute(args, _ctx) {
-          const deleted = deleteMemory(worktree, args.file_name)
+          const deleted = deleteMemory(memoryRoot, args.file_name)
           return deleted ? `Memory "${args.file_name}" deleted.` : `Memory "${args.file_name}" not found.`
         },
       }),
@@ -449,7 +461,7 @@ export const MemoryPlugin: Plugin = async ({ worktree, directory, client }) => {
           "or when you need to recall what's been stored.",
         args: {},
         async execute(_args, ctx) {
-          const entries = listMemories(worktree)
+          const entries = listMemories(memoryRoot)
           const callID = getCallID(ctx)
           if (callID) memoryListCountByCallID.set(callID, entries.length)
           if (entries.length === 0) {
@@ -470,7 +482,7 @@ export const MemoryPlugin: Plugin = async ({ worktree, directory, client }) => {
           query: tool.schema.string().describe("Search query — searches across name, description, and content"),
         },
         async execute(args, ctx) {
-          const results = searchMemories(worktree, args.query)
+          const results = searchMemories(memoryRoot, args.query)
           const callID = getCallID(ctx)
           if (callID) memorySearchCountByCallID.set(callID, results.length)
           if (results.length === 0) {
@@ -489,7 +501,7 @@ export const MemoryPlugin: Plugin = async ({ worktree, directory, client }) => {
           file_name: tool.schema.string().describe("File name of the memory to read (with or without .md extension)"),
         },
         async execute(args, _ctx) {
-          const entry = readMemory(worktree, args.file_name)
+          const entry = readMemory(memoryRoot, args.file_name)
           if (!entry) {
             return `Memory "${args.file_name}" not found.`
           }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -4,12 +4,19 @@ import { tmpdir } from "os"
 import { join } from "path"
 import { MemoryPlugin } from "../src/index.js"
 import { saveMemory } from "../src/memory.js"
+import { getMemoryDir } from "../src/paths.js"
 
 const tempDirs: string[] = []
 
 function makeTempGitRepo(): string {
   const root = mkdtempSync(join(tmpdir(), "index-test-"))
   mkdirSync(join(root, ".git"), { recursive: true })
+  tempDirs.push(root)
+  return root
+}
+
+function makeTempProject(): string {
+  const root = mkdtempSync(join(tmpdir(), "index-test-project-"))
   tempDirs.push(root)
   return root
 }
@@ -86,6 +93,31 @@ function makeCompletedSelectorClient(selections: string[][]) {
 }
 
 describe("MemoryPlugin system transform", () => {
+  test("uses directory as memory root when OpenCode reports root worktree", async () => {
+    const project = makeTempProject()
+    const configDir = mkdtempSync(join(tmpdir(), "index-test-claude-"))
+    tempDirs.push(configDir)
+    const originalConfigDir = process.env.CLAUDE_CONFIG_DIR
+    process.env.CLAUDE_CONFIG_DIR = configDir
+
+    try {
+      const expectedMemoryDir = getMemoryDir(project)
+      const rootMemoryDir = getMemoryDir("/")
+      const plugin = await MemoryPlugin({ worktree: "/", directory: project } as never)
+      const transform = plugin["experimental.chat.system.transform"] as unknown as SystemTransform
+      const output = { system: [] as string[] }
+
+      await transform({ model: "test-model", sessionID: "ses_root_worktree" }, output)
+
+      expect(output.system).toHaveLength(1)
+      expect(output.system[0]).toContain(expectedMemoryDir)
+      expect(output.system[0]).not.toContain(rootMemoryDir)
+    } finally {
+      if (originalConfigDir === undefined) delete process.env.CLAUDE_CONFIG_DIR
+      else process.env.CLAUDE_CONFIG_DIR = originalConfigDir
+    }
+  })
+
   test("suppresses memory context when user explicitly asks to ignore memory", async () => {
     const repo = makeTempGitRepo()
     saveMemory(repo, "hidden", "Hidden Memory", "Should be ignored", "user", "Secret context")


### PR DESCRIPTION
## Summary

Fixes #19.

OpenCode can report `worktree` as the filesystem root (`/`) while the active project path is available as `directory`. The plugin previously used `worktree` for all memory operations, which made non-git projects resolve to `~/.claude/projects/-/memory` instead of the project-specific Claude memory path.

This PR resolves the effective memory root once during plugin setup: when `worktree` is the filesystem root and `directory` points at a real project directory, memory prompt injection, recall prefetch, and memory tools all use `directory`.

## Validation

- Added a regression test for `worktree="/"` with a non-root `directory`, asserting the generated system prompt uses the project-specific memory directory and not `projects/-/memory`.
- `bun test`
- `bun run build`
