### PR TITLE
docs: improve package discoverability metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# OpenCode plugin for Claude Code memory
+# 🧠 Claude Code-compatible memory for OpenCode
 
 **Persistent, local-first shared memory for OpenCode and Claude Code — zero config and no migration required.**
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 <div align="center">
 
-# 🧠 Claude Code-compatible memory for OpenCode
+# OpenCode plugin for Claude Code memory
 
-**Make OpenCode and Claude Code share the same memory — zero config, local-first, and no migration required.**
+**Persistent, local-first shared memory for OpenCode and Claude Code — zero config and no migration required.**
+
+This OpenCode memory plugin lets OpenCode read and write Claude Code-compatible Markdown memory files, so both CLIs share the same project context.
 
 Claude Code writes memory → OpenCode reads it. OpenCode writes memory → Claude Code reads it.
 
@@ -18,6 +20,8 @@ Claude Code writes memory → OpenCode reads it. OpenCode writes memory → Clau
 
 ## ✨ At a glance
 
+- **OpenCode plugin for Claude Code memory**
+  Adds persistent memory tools, system prompt injection, and post-session extraction to OpenCode.
 - **Claude Code-compatible memory**
   Uses Claude Code’s existing memory paths, file format, and taxonomy.
 - **Zero config**

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "opencode-claude-memory",
   "version": "0.0.0-semantically-released",
   "type": "module",
-  "description": "Claude Code-compatible memory compatibility layer for OpenCode — zero config, local-first, no migration",
+  "description": "OpenCode plugin for Claude Code memory: persistent, local-first shared memory with Claude Code-compatible Markdown files, auto extraction, and auto-dream",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {
@@ -26,13 +26,29 @@
     "type": "git",
     "url": "git+https://github.com/kuitos/opencode-claude-memory.git"
   },
+  "bugs": {
+    "url": "https://github.com/kuitos/opencode-claude-memory/issues"
+  },
   "homepage": "https://github.com/kuitos/opencode-claude-memory#readme",
   "keywords": [
     "opencode",
+    "opencode-plugin",
+    "opencode-ai",
+    "claude",
+    "claude-code",
+    "claude-code-memory",
+    "claude-memory",
     "plugin",
     "memory",
-    "persistent",
-    "cross-session",
+    "persistent-memory",
+    "agent-memory",
+    "ai-memory",
+    "cross-session-memory",
+    "shared-memory",
+    "local-first",
+    "markdown-memory",
+    "coding-agent",
+    "developer-tools",
     "claude-code-compatible"
   ],
   "license": "MIT",


### PR DESCRIPTION
## What changed

- Updated the README hero copy to target the natural search phrase "OpenCode plugin for Claude Code memory".
- Expanded npm package metadata with `opencode-plugin`, `claude-code-memory`, `persistent-memory`, and related discoverability keywords.
- Added the package `bugs` URL so npm exposes the GitHub issue tracker link.

## Why

The project was hard to find through GitHub, npm, and Google for queries like `opencode Claude memory`. The package and repo metadata did not cover several common ecosystem search terms used by comparable packages.

## Validation

- `git diff --check`
- `bun run build`